### PR TITLE
fix(ellipsis): make ellisis 2 & 3 line work in the styleguide

### DIFF
--- a/src/pivotal-ui/components/ellipsis.css.scss
+++ b/src/pivotal-ui/components/ellipsis.css.scss
@@ -7,40 +7,37 @@ categories:
   - Utilities
 ---
 
-NB: This only works on webkit.
-
-```haml_example
-%p.type-ellipsis-2-lines Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-%p.type-ellipsis-3-lines Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-```
-
-*/
-.type-ellipsis-2-lines {
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-}
-.type-ellipsis-3-lines {
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-}
-
-/*doc
----
-title: Single line Ellipsis
-name: ellipsis_1_line
-parent: ellipsis
----
-
 The type `.type-ellipsis-1-line` adds ellipsis to text when there is too much. Combine it with `.col-md-*` classes to get the width you want.
 
-```haml_example
-%p.type-ellipsis-1-line Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+```haml_example_table
+%p.type-ellipsis-1-line
+  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+%p.type-ellipsis-2-lines
+  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+%p.type-ellipsis-3-lines
+  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 ```
+
+
+<div class="alert alert-info">
+  <p>Multi-line ellipsis only works on webkit.</p>
+</div>
 
 */
 
 .type-ellipsis-1-line {
   @include ellipsis;
+}
+
+.type-ellipsis-2-lines,
+.type-ellipsis-3-lines {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.type-ellipsis-3-lines {
+  -webkit-line-clamp: 3;
 }

--- a/src/style_guide/style_guide.scss
+++ b/src/style_guide/style_guide.scss
@@ -261,6 +261,7 @@ table.styleguide {
   border: 1px solid #ccc;
   width: 100%;
   margin-bottom: 12px;
+  table-layout: fixed;
 
   tr, th, td {
     padding: 7px;


### PR DESCRIPTION
[Finishes #80751262]
- Also sets table layout fixed for code tables so both sections take up 50% of the table width

Signed-off-by: Nicole Sullivan nsullivan@pivotal.io
