### PR TITLE
Forms

### DIFF
--- a/src/pivotal-ui/components/forms.scss
+++ b/src/pivotal-ui/components/forms.scss
@@ -1,5 +1,54 @@
 /*doc
 ---
+title: Introduction
+name: 00_form_introduction
+categories:
+  - All
+  - Forms
+---
+
+Individual form controls automatically receive some global styling.
+All textual `<input>`, `<textarea>`, and `<select>` elements with
+`.form-control` are set to `width: 100`%; by default.
+
+<div class="alert alert-info">
+  <p class="em-high">
+    Wrap labels and controls in <code>.form-group</code> for optimum spacing.
+  </p>
+</div>
+
+*/
+
+/*doc
+---
+title: Basic Forms
+name: 0a_form_basic
+parent: 00_form_introduction
+---
+
+```html_example
+<form role="form">
+  <div class="form-group">
+    <label for="exampleInputEmail1">Email address</label>
+    <input type="email" class="form-control" id="exampleInputEmail1" placeholder="Enter email">
+  </div>
+  <div class="form-group">
+    <label for="exampleInputPassword1">Password</label>
+    <input type="password" class="form-control" id="exampleInputPassword1" placeholder="Password">
+  </div>
+  <div class="checkbox">
+    <label>
+      <input type="checkbox"> Check me out
+    </label>
+  </div>
+  <button type="submit" class="btn btn-default">Submit</button>
+</form>
+```
+
+*/
+
+/*doc
+---
 title: Inline Forms
 name: form_inline
 categories:
@@ -7,17 +56,18 @@ categories:
   - Forms
 ---
 
-Add `.form-inline` to your `<form>` for left-aligned and inline-block controls. This only applies to forms within viewports that are at least 768px wide.
+Add `.form-inline` to your `<form>` for left-aligned and inline-block controls.
+This only applies to forms within viewports that are at least 768px wide.
 
 <div class="alert alert-info">
   <h5 class="em-high mtn">
     Always add labels to every input.
   </h5>
   <p>
-    Screen readers will have trouble with your forms if you don't. You can always hide the labels using the <code class="sg-code">.sr-only</code> class.
+    Screen readers will have trouble with your forms if you don't.
+    You can always hide the labels using the <code class="sg-code">.sr-only</code> class.
   </p>
 </div>
-
 
 ```haml_example
 %form.styleguide-form.form-inline{:role => "form"}


### PR DESCRIPTION
This PR:
- Marks "Focus Input" as pending, since it is broken
- Reorganizes content in the forms category
- Fixes errors that caused some of the categories to be missing from the documentation
- Adds a basic form example to the top of the forms page

It's probably best to check this PR out and see the changes IRL
