### PR TITLE
fix(styleguide): improve font rendering for h3 styles on IE9 and IE10

### DIFF
--- a/src/styleguide/ie-specific-styles.scss
+++ b/src/styleguide/ie-specific-styles.scss
@@ -10,5 +10,8 @@
       font-size: 10px !important;
     }
   }
+  h3, .h3 {
+    font-size: 22px;
+  }
 }
 


### PR DESCRIPTION
[Finishes #82065438]

Signed-off-by: Bebe Peng bpeng@pivotal.io
