### PR TITLE
fix(list-group): background color is now transparent

### DIFF
--- a/src/pivotal-ui/components/variables.scss
+++ b/src/pivotal-ui/components/variables.scss
@@ -930,7 +930,7 @@ $list-steps-color-current:    $gray-10;
 
 // List group
 // -------------------------
-$list-group-bg:               #fff !default;
+$list-group-bg:               transparent !default;
 $list-group-border:           #ddd !default;
 $list-group-border-radius:    $border-radius-none !default;
 


### PR DESCRIPTION
- background color is no longer white
- add class .bg-neutral-11 if a white background is desired
- $list-group-bg is now transparent

[Finishes #82482472]
