### PR TITLE
fix(table): remove superfluous extension of `.row`

### DIFF
--- a/src/pivotal-ui/components/tables.scss
+++ b/src/pivotal-ui/components/tables.scss
@@ -213,7 +213,6 @@ specify column widths for the th/tds.
   }
   tbody {
     tr {
-      @extend .row;
       &:last-child {
         border: none;
       }


### PR DESCRIPTION
Tables shouldn't extend grid css directives

[Fixes #82484402]
