### PR TITLE
feat(code): pre-scrollable heights are now auto

### DIFF
--- a/src/pivotal-ui/components/code.scss
+++ b/src/pivotal-ui/components/code.scss
@@ -116,11 +116,13 @@ Scrollable with too little content:
         end
       end
 ```
+
+If you would like a set a default height, please add it manually.
+
 */
 
 .pre-scrollable {
   overflow-y: auto; //bootstrap override
-  height: 295px; //bootstrap override
 }
 
 /*doc


### PR DESCRIPTION
- no longer a default height of 295px

[Finishes #82747156]

Signed-off-by: Paul Meskers pmeskers@pivotal.io
