### PR TITLE
fix(tab-simple): active tabs no longer have borders on non-hover states

### DIFF
--- a/src/pivotal-ui/components/tabs.scss
+++ b/src/pivotal-ui/components/tabs.scss
@@ -189,6 +189,7 @@ $tab-border-size: 3px;
       @include no-transition;
 
       > a {
+        border: 0;
         margin: -$tab-border-size 0 $tab-border-size 0; //shift text up to offset top border
         color: $tab-simple-link-active-color;
         background-color: transparent;


### PR DESCRIPTION
fixes weird bug from upgraded chrome
