### PR TITLE
Make readonly fields look readonly

### DIFF
--- a/src/pivotal-ui/components/forms.scss
+++ b/src/pivotal-ui/components/forms.scss
@@ -504,7 +504,7 @@ Add the `readonly` boolean attribute on an input to prevent user input and style
 }
 
 .form-control[readonly] {
-  background-color: $btn-disabled-bg; //override bootstrap
+  background-color: $input-bg-disabled; //override bootstrap
 }
 
 /*doc


### PR DESCRIPTION
I changed a text input to 'readonly' in my app and lost the greyed-out appearance that 'disabled' displays. Recommending we change this to a color var ($btn-disabled-bg) rather than setting the background color to 'transparent'.
