### PR TITLE
chore(jslint): Lint all JS/JSX files.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -14,7 +14,6 @@
   "noarg": true,
   "node": true,
   "nonew": true,
-  "quotmark": "single",
   "strict": true,
   "sub": true,
   "undef": true,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,8 @@ var argv = require('yargs').argv,
   replace = require('gulp-replace'),
   shell = require('gulp-shell'),
   source = require('vinyl-source-stream'),
-  stylish = require('jshint-stylish');
+  stylish = require('jshint-stylish'),
+  jsxTransform = require('gulp-react');
 
 require('./tasks/test.js');
 require('./tasks/release.js');
@@ -39,7 +40,8 @@ gulp.task('serve', function() {
 });
 
 gulp.task('lint', function() {
-  return gulp.src('./src/pivotal-ui/javascripts/**/*.js')
+  return gulp.src('./src/pivotal-ui/javascripts/**/*.js?(x)')
+    .pipe(jsxTransform())
     .pipe(jshint().on('error', errorHandler.handleError))
     .pipe(jshint.reporter(stylish))
     .pipe(jshint.reporter('fail'));

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gulp-jshint": "^1.8.5",
     "gulp-minify-css": "^0.3.11",
     "gulp-open": "^0.2.8",
+    "gulp-react": "^2.0.0",
     "gulp-rename": "^1.2.0",
     "gulp-replace": "^0.5.0",
     "gulp-shell": "^0.2.10",

--- a/src/pivotal-ui/javascripts/buttons.jsx
+++ b/src/pivotal-ui/javascripts/buttons.jsx
@@ -40,7 +40,7 @@ var DefaultButton = React.createClass({
   getDefaultProps: function () {
     return {
       type: 'default'
-    }
+    };
   },
 
   render: function render() {
@@ -53,7 +53,7 @@ var DefaultAltButton = React.createClass({
   getDefaultProps: function () {
     return {
       type: 'default-alt'
-    }
+    };
   },
 
   render: function render() {
@@ -66,7 +66,7 @@ var PrimaryButton = React.createClass({
   getDefaultProps: function () {
     return {
       type: 'primary'
-    }
+    };
   },
 
   render: function render() {
@@ -79,7 +79,7 @@ var LowlightButton = React.createClass({
   getDefaultProps: function () {
     return {
       type: 'lowlight'
-    }
+    };
   },
 
   render: function render() {
@@ -92,7 +92,7 @@ var DangerButton = React.createClass({
   getDefaultProps: function () {
     return {
       type: 'danger'
-    }
+    };
   },
 
   render: function render() {
@@ -105,7 +105,7 @@ var HighlightButton = React.createClass({
   getDefaultProps: function () {
     return {
       type: 'highlight'
-    }
+    };
   },
 
   render: function render() {
@@ -118,7 +118,7 @@ var HighlightAltButton = React.createClass({
   getDefaultProps: function () {
     return {
       type: 'highlight-alt'
-    }
+    };
   },
 
   render: function render() {

--- a/src/pivotal-ui/javascripts/dividers.jsx
+++ b/src/pivotal-ui/javascripts/dividers.jsx
@@ -1,7 +1,6 @@
 'use strict';
 
 var React = require('react');
-var _ = require('lodash');
 
 var Divider = React.createClass({
   render: function () {
@@ -9,13 +8,13 @@ var Divider = React.createClass({
     var classes = [];
 
     if (!this.props.inverse) {
-      typeName += "-alternate"
+      typeName += "-alternate";
     }
 
-    if (this.props.size == "large") {
-      typeName += "-2"
+    if (this.props.size === "large") {
+      typeName += "-2";
     } else {
-      typeName += "-1"
+      typeName += "-1";
     }
 
     classes.push(typeName);

--- a/src/pivotal-ui/javascripts/inputs.jsx
+++ b/src/pivotal-ui/javascripts/inputs.jsx
@@ -1,7 +1,6 @@
 'use strict';
 
 var React = require('react');
-var _ = require('lodash');
 
 var SearchInput = React.createClass({
   render: function () {

--- a/src/pivotal-ui/javascripts/media.jsx
+++ b/src/pivotal-ui/javascripts/media.jsx
@@ -1,7 +1,6 @@
 'use strict';
 
 var React = require('react/addons');
-var _ = require('lodash');
 var setClass = React.addons.classSet;
 
 var MediaObject = React.createClass({

--- a/src/pivotal-ui/javascripts/panes.jsx
+++ b/src/pivotal-ui/javascripts/panes.jsx
@@ -1,7 +1,6 @@
 'use strict';
 
 var React = require('react');
-var _ = require('lodash');
 
 var BasePane = React.createClass({
   render: function () {

--- a/src/pivotal-ui/javascripts/pivnet_homepage.jsx
+++ b/src/pivotal-ui/javascripts/pivnet_homepage.jsx
@@ -1,7 +1,11 @@
 'use strict';
 
 var React = require('react');
-var _ = require('lodash');
+var DefaultH1 = require('./typography.jsx').DefaultH1;
+var DefaultH2 = require('./typography.jsx').DefaultH1;
+var DividerInverse = require('./dividers.jsx').DividerInverse;
+var Pane = require('./panes.jsx').Pane;
+var HighlightAltButton = require('./buttons.jsx').HighlightAltButton;
 
 var PivnetHomepage = React.createClass({
   render: function () {

--- a/src/pivotal-ui/javascripts/table-sortable.jsx
+++ b/src/pivotal-ui/javascripts/table-sortable.jsx
@@ -4,7 +4,7 @@ var React = require('react');
 var _ = require('lodash');
 
 var TableHeader = React.createClass({
-  handleClick: function handleClick(e) {
+  handleClick: function handleClick() {
     if (this.props.sortable) {
       this.props.onSortableTableHeaderClick(this);
     }

--- a/src/pivotal-ui/javascripts/typography.jsx
+++ b/src/pivotal-ui/javascripts/typography.jsx
@@ -3,7 +3,6 @@
 var React = require('react');
 var _ = require('lodash');
 
-
 var Heading = React.createClass({
   acceptedSizeClasses: ['title', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'small'],
   acceptedBoldClasses: ['low', 'default', 'high', 'max'],
@@ -19,11 +18,11 @@ var Heading = React.createClass({
     }
 
     if (_.contains(this.acceptedBoldClasses, this.props.bold)) {
-      classes.push("em-" + this.props.bold);
+      classes.push('em-' + this.props.bold);
     }
 
     if (this.props.allCaps) {
-      classes.push("em-alt");
+      classes.push('em-alt');
     }
 
     if (this.props.color) {
@@ -33,17 +32,17 @@ var Heading = React.createClass({
     var joinedClasses = classes.join(' ');
 
     switch(this.props.element) {
-      case "h1":
+      case 'h1':
         return (<h1 {...this.props} className={joinedClasses}>{this.props.children}</h1>);
-      case "h2":
+      case 'h2':
         return (<h2 {...this.props} className={joinedClasses}>{this.props.children}</h2>);
-      case "h3":
+      case 'h3':
         return (<h3 {...this.props} className={joinedClasses}>{this.props.children}</h3>);
-      case "h4":
+      case 'h4':
         return (<h4 {...this.props} className={joinedClasses}>{this.props.children}</h4>);
-      case "h5":
+      case 'h5':
         return (<h5 {...this.props} className={joinedClasses}>{this.props.children}</h5>);
-      case "h6":
+      case 'h6':
         return (<h6 {...this.props} className={joinedClasses}>{this.props.children}</h6>);
       default:
         return (<p {...this.props} className={joinedClasses}> {this.props.children}</p>);
@@ -59,7 +58,7 @@ var createTypographyClass = function createTypographyClass(opts) {
         size: opts.size,
         bold: opts.bold,
         allCaps: opts.allCaps
-      }
+      };
     },
 
     render: function render() {


### PR DESCRIPTION
- This chore disables linting of quotation types due to React
  compiling our JSX and adding double quoted strings
- Fixes all offending warnings (mainly, missing semicolons
  and unused variables)

[#85347372]

-- This also adds the gulp-react plugin for gulp, since we needed something that _only_ compiled our JSX without browserifying it. See related story in Tracker for more detail.
