### PR TITLE
fix(ie-support): fix back to top component in IE9

### DIFF
--- a/src/pivotal-ui/javascripts/utils.js
+++ b/src/pivotal-ui/javascripts/utils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Modernizr = require('modernizr');
+
 var breakpoints = {
   xsMin: 480,
   smMin: 768,
@@ -31,5 +33,5 @@ module.exports = window.utils = {
 };
 
 function isMinWidth(width) {
-  return window.matchMedia('(min-width: ' + width + 'px)').matches;
+  return Modernizr.mq('(min-width: ' + width + 'px)');
 }


### PR DESCRIPTION
- Uses Modernizr.mq instead of window.matchMedia
- Modernizr.mq has IE9 support, where as window.matchMedia does not

[Finishes #84119472]

Signed-off-by: Bebe Peng bpeng@pivotal.io
