### PR TITLE
fix(nginx): Our CF-deployed app uses custom nginx.conf char encoding

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,0 +1,34 @@
+worker_processes 1;
+daemon off;
+
+error_log <%= ENV["APP_ROOT"] %>/nginx/logs/error.log;
+events { worker_connections 1024; }
+
+http {
+  charset UTF-8;
+  log_format cloudfoundry '$http_x_forwarded_for - $http_referer - [$time_local] "$request" $status $body_bytes_sent';
+  access_log <%= ENV["APP_ROOT"] %>/nginx/logs/access.log cloudfoundry;
+  default_type application/octet-stream;
+  include mime.types;
+  sendfile on;
+  gzip on;
+  tcp_nopush on;
+  keepalive_timeout 30;
+
+  server {
+    listen <%= ENV["PORT"] %>;
+    server_name localhost;
+
+    location / {
+      root <%= ENV["APP_ROOT"] %>/public;
+      index index.html index.htm Default.htm;
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_directory_index")) %>
+      autoindex on;
+      <% end %>
+      <% if File.exists?(auth_file = File.join(ENV["APP_ROOT"], "nginx/conf/.htpasswd")) %>
+      auth_basic "Restricted";                                #For Basic Auth
+      auth_basic_user_file <%= auth_file %>;  #For Basic Auth
+      <% end %>
+    }
+  }
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -192,6 +192,7 @@ gulp.task('_otherAssets', [
   '_copyStyleguideAssets',
   '_copyStaticfile',
   '_copyZeroClipboard',
+  '_copyNginxConf',
 ]);
 
 gulp.task('_cleanOtherAssets', function(done) {
@@ -247,6 +248,11 @@ gulp.task('_copyZeroClipboard', ['_cleanOtherAssets'], function() {
     'node_modules/zeroclipboard/dist/ZeroClipboard.swf',
   ])
     .pipe(gulp.dest('./build/zeroclipboard/'));
+});
+
+gulp.task('_copyNginxConf', ['_cleanOtherAssets'], function() {
+  return gulp.src(['config/nginx.conf'])
+    .pipe(gulp.dest('./build/'));
 });
 
 


### PR DESCRIPTION
- This will fix the react-alert bug where the 'x' is a 'A-'
- This is not a clean solution... it requires us to maintain an
  nginx.conf. Hoping to get this into the static buildpack, but this
  will make our styleguide use the correct char encoding in the meantime.

[Fixes #85646924]

FYI -- the source of the nginx.conf I used here is the one our buildpack uses by default.
