### PR TITLE
Newly added list items are correctly aligned.

### DIFF
--- a/src/pivotal-ui/components/lists.scss
+++ b/src/pivotal-ui/components/lists.scss
@@ -396,11 +396,13 @@ New elements fade in
 @-webkit-keyframes new-list-group-item-grow {
   0% {
     max-height: 0;
-    padding: 0px 15px;
+    padding-top: 0px;
+    padding-bottom: 0px;
   }
   100% {
     max-height: 100px;
-    padding: 10px 15px;
+    padding-top:10px;
+    padding-bottom:10px;
   }
 }
 


### PR DESCRIPTION
- removed padding on .list-group-item.new
- added an example to the style guide.
- this relates to apps-manager bug
  https://www.pivotaltracker.com/story/show/85580602

Signed-off-by: Tira Odhner todhner@pivotal.io
