### PR TITLE
Fix a bug where link cards wrapped badly on hover and link did not cover the whole card.

### DIFF
--- a/src/pivotal-ui/components/lists.scss
+++ b/src/pivotal-ui/components/lists.scss
@@ -946,7 +946,7 @@ wrap all the inner content in `a` with class `list-card-link`.
       a.list-cards-link, // deprecated in favor of the singular
       a.list-card-link {
         display: block;
-        min-height: $height;
+        height: $height;
       }
 
       .list-card-wrapper {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/87260340.

Signed-off-by: Ross Greenwood rgreenwood@pivotal.io
