### PR TITLE
fix(.new.list-group-item): content of .new.list-group-item no longer extends beyond div during animation

### DIFF
--- a/src/pivotal-ui/components/lists.scss
+++ b/src/pivotal-ui/components/lists.scss
@@ -379,6 +379,7 @@ New elements fade in
   padding-right: 5px; //bootstrap override
 
   &.new {
+    overflow:hidden;
     -webkit-animation: new-list-group-item-grow .3s cubic-bezier(0.895, 0.03, 0.685, 0.22) forwards, new-list-group-item-fade .5s ease-in .15s forwards;
     -moz-animation: new-list-group-item-grow .3s cubic-bezier(0.895, 0.03, 0.685, 0.22) forwards, new-list-group-item-fade .5s ease-in .15s forwards;
   }
@@ -399,10 +400,13 @@ New elements fade in
     padding-top: 0px;
     padding-bottom: 0px;
   }
-  100% {
+  99% {
     max-height: 100px;
-    padding-top:10px;
-    padding-bottom:10px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+  100% {
+    max-height: initial;
   }
 }
 


### PR DESCRIPTION
This is a fix for https://github.com/pivotal-cf/pivotal-ui/issues/143
- this used to happen when a .list-group-item was added to the DOM with the
  'new' class applied to it
- using overflow:hidden to prevent contents from exceeding bounds of the .list-group-item div
- added an extra frame to jump to the initial max height in the event that list item contents are larger than 100px. We can't smoothly animate to initial height due to limitation of css3 animations (they require a pixel value to animate to) In that case the end of the animation will not be as smooth but at least the full content will be shown after the animation ends.

Signed-off-by: Alex Stupakov astupakov@pivotal.io
