### PR TITLE
chore(fonts): change source-sans-pro.css paths

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -106,7 +106,10 @@ gulp.task('_sassBuildPuiRails', ['_sassBuildPui'], function() {
       replace(/url\(('|")\.\.\/fonts\//g, 'font-url\($1fonts/')
     )
     .pipe(
-      replace(/url\(('|")\.\.\/images\//g, 'image-url\($1images/')
+      replace(/url\(('|")fonts\//g, 'font-url\($1fonts/')
+    )
+    .pipe(
+      replace(/url\(('|")images\//g, 'image-url\($1images/')
     )
     .pipe(rename('pivotal-ui-rails.css'))
     .pipe(gulp.dest('build/'));


### PR DESCRIPTION
In our gulp task for creating our rails.scss file, we use some pretty specific regex. Currently, none of our source sans pro fonts are being found.

We changed the source-sans-pro-css.scss file to be consistant with the FontAwesome paths so that our gulp task can do a full search and replaces for font_url. 

When running gulp the our rails scss file should have replaced all of the urls for fonts with font_url.
