### PR TITLE
Allow Pivotal UI to be required as a node module

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "description": "***",
   "version": "1.6.0",
-  "main": "gulpfile.js",
+  "main": "src/pivotal-ui/javascripts/pivotal-ui.js",
   "dependencies": {
     "autoprefixer-core": "^5.1.8",
     "bootstrap-sass": "3.3.1",


### PR DESCRIPTION
Hi Pivotal UI team,

We wanted to load Pivotal UI into our [SSL Service project](https://github.com/pivotal-cf/ssl-service) as a node module to clean up our build pipeline. This small change was all that was necessary to get this working.

-CF LA