### PR TITLE
Improve notifications

### DIFF
--- a/src/pivotal-ui-react/notifications/notifications.js
+++ b/src/pivotal-ui-react/notifications/notifications.js
@@ -39,7 +39,7 @@ var Notifications = React.createClass({
     var badge = children ? <span className="dropdown-notifications-badge">{numChildren}</span> : null;
     var dropdownTitle = (
       <div className="dropdown-notifications-title">
-        <i className="fa fa-bell type-neutral-6 h2 mvn"></i>
+        <i className="fa fa-bell"></i>
         {badge}
       </div>
     );

--- a/src/pivotal-ui-react/notifications/notifications.js
+++ b/src/pivotal-ui-react/notifications/notifications.js
@@ -86,10 +86,10 @@ var Notifications = React.createClass({
 var AlertNotifications = React.createClass({
   render() {
     var {children} = this.props;
-    var badge = children ? <Icon name="exclamation-triangle" className="dropdown-notifications-alert h4 type-warn-2"></Icon> : null;
+    var badge = children ? <Icon name="exclamation-triangle" className="dropdown-notifications-alert"></Icon> : null;
     var dropdownTitle = (
       <div className="dropdown-notifications-title">
-        <i className="fa fa-bell type-neutral-6 fa-h2 mvn"></i>
+        <i className="fa fa-bell"></i>
         {badge}
       </div>
     );

--- a/src/pivotal-ui-react/notifications/notifications.js
+++ b/src/pivotal-ui-react/notifications/notifications.js
@@ -46,7 +46,7 @@ var Notifications = React.createClass({
     children = children || (
       <li role="presentation">
         <div className="dropdown-notifications-none">
-          <Icon name="bell" className="type-neutral-6"/>
+          <Icon name="bell"/>
           <p className="type-neutral-4 em-alt mbn">no notifications</p>
         </div>
       </li>
@@ -96,7 +96,7 @@ var AlertNotifications = React.createClass({
     children = children || (
       <li role="presentation">
         <div className="dropdown-notifications-none">
-          <Icon name="bell" className="type-neutral-6"/>
+          <Icon name="bell"/>
           <p className="type-neutral-4 em-alt mbn">no alerts</p>
         </div>
       </li>

--- a/src/pivotal-ui/components/dropdowns/dropdowns.scss
+++ b/src/pivotal-ui/components/dropdowns/dropdowns.scss
@@ -269,6 +269,30 @@ This is a notification dropdown with notifications.
 </div>
 ```
 
+Here's an example modifiying the size and the color of the bell
+
+```html_example
+<div class="dropdown-notifications btn-group">
+  <button data-toggle="dropdown" class="dropdown-toggle btn btn-link" type="button">
+    <div class="dropdown-notifications-title h1">
+      <i class="fa fa-bell type-neutral-2"></i>
+      <span class="dropdown-notifications-badge">42</span>
+    </div>
+  </button>
+  <ul class="dropdown-menu" role="menu">
+    <li role="presentation">
+      <a role="menuitem" href="https://twitter.com/fat">Item 1</a>
+    </li>
+    <li role="presentation">
+      <a role="menuitem" href="https://twitter.com/fat">...</a>
+    </li>
+    <li role="presentation">
+      <a role="menuitem" href="https://twitter.com/fat">Item 42</a>
+    </li>
+  </ul>
+</div>
+```
+
 This is a notification dropdown with alerts.
 
 ```html_example

--- a/src/pivotal-ui/components/dropdowns/dropdowns.scss
+++ b/src/pivotal-ui/components/dropdowns/dropdowns.scss
@@ -207,10 +207,12 @@ parent: dropdown
 This is a notification dropdown with no notifications.
 
 ```html_example
-<div class="dropdown btn-group">
-  <a data-toggle="dropdown" class="dropdown-toggle btn btn-link" type="button">
-    <i class="fa fa-bell type-neutral-6 h2 mvn mrm"></i>
-  </a>
+<div class="dropdown-notifications btn-group">
+  <button data-toggle="dropdown" class="dropdown-toggle btn btn-link" type="button">
+    <div class="dropdown-notifications-title">
+      <i class="fa fa-bell"></i>
+    </div>
+  </button>
   <ul class="dropdown-menu" role="menu">
     <li role="presentation">
       <div class="dropdown-notifications-none">
@@ -225,9 +227,91 @@ This is a notification dropdown with no notifications.
 This is a notification dropdown with notifications.
 
 ```html_example
+<div class="dropdown-notifications btn-group">
+  <button data-toggle="dropdown" class="dropdown-toggle btn btn-link" type="button">
+    <div class="dropdown-notifications-title">
+      <i class="fa fa-bell"></i>
+      <span class="dropdown-notifications-badge">2</span>
+    </div>
+  </button>
+  <ul class="dropdown-menu" role="menu">
+    <li role="presentation">
+      <a role="menuitem" href="https://twitter.com/fat">
+        <div class="media">
+          <div class="media-left media-middle">
+            <h3 class="mvn">
+              <span class="label label-primary">New</span>
+            </h3>
+          </div>
+          <div class="media-body media-middle">
+            <h5 class="media-heading mbn type-dark-1">Notification</h5>
+            <p class="type-sm type-neutral-5 mvn">News for you</p>
+          </div>
+        </div>
+      </a>
+    </li>
+    <li role="presentation">
+      <a role="menuitem" href="https://twitter.com/fat">
+        <div class="media">
+          <div class="media-left media-middle">
+            <h3 class="mvn">
+              <span class="label label-primary">New</span>
+            </h3>
+          </div>
+          <div class="media-body media-middle">
+            <h5 class="media-heading mbn type-dark-1">Pivotal-CF</h5>
+            <p class="type-sm type-neutral-5 mvn">1 New File Available</p>
+          </div>
+        </div>
+      </a>
+    </li>
+  </ul>
+</div>
+```
+
+This is a notification dropdown with alerts.
+
+```html_example
+<div class="dropdown-notifications btn-group">
+  <button data-toggle="dropdown" class="dropdown-toggle btn btn-link" type="button">
+    <div class="dropdown-notifications-title">
+      <i class="fa fa-bell"></i>
+      <i class="fa fa-exclamation-triangle dropdown-notifications-alert type-warn-2"></i>
+    </div>
+  </button>
+  <ul class="dropdown-menu" role="menu">
+    <li role="presentation">
+      <a role="menuitem" href="https://twitter.com/fat">
+        <div class="media">
+          <div class="media-left media-middle">
+            <i class="fa fa-exclamation-triangle type-warn-2 mrm"></i>
+          </div>
+          <div class="media-body media-middle">
+            <h5 class="media-heading mbn type-dark-1">Warning</h5>
+            <p class="type-sm type-neutral-5 mvn">News for you</p>
+          </div>
+        </div>
+      </a>
+    </li>
+  </ul>
+</div>
+```
+
+<div class="alert alert-danger mbxl">
+  <h5 class="em-high mtn">
+    Deprecation warning
+  </h5>
+  <p>
+    The example below shows the old markup for notifications alerts. It will
+    not be supported in the next major release. Please change your notifications
+    to match the examples above.
+  </p>
+</div>
+
+```html_example
 <div class="dropdown btn-group">
   <a data-toggle="dropdown" class="dropdown-toggle btn btn-link" type="button">
-    <i class="fa fa-bell type-neutral-6 h2 mvn"></i>
+    <i class="fa fa-bell type-neutral-6 mvn h2"></i>
     <span class="dropdown-notifications-badge">2</span>
   </a>
   <ul class="dropdown-menu dropdown-notifications-list" role="menu">
@@ -260,83 +344,26 @@ This is a notification dropdown with notifications.
   </ul>
 </div>
 ```
-
-This is a notification dropdown with alerts.
-
-```html_example
-<div class="dropdown btn-group">
-  <a data-toggle="dropdown" class="dropdown-toggle btn btn-link" type="button">
-    <i class="fa fa-bell type-neutral-6 h2 mvn"></i>
-    <i class="fa fa-exclamation-triangle h4 type-warn-2 dropdown-notifications-alert"></i>
-  </a>
-  <ul class="dropdown-menu dropdown-notifications-list" role="menu">
-    <li role="presentation">
-      <a role="menuitem" href="https://twitter.com/fat">
-        <div class="media man pan">
-          <div class="media-left media-middle">
-            <i class="fa fa-exclamation-triangle type-warn-2 h4 mrm"></i>
-          </div>
-          <div class="media-body media-middle">
-            <h5 class="media-heading mbn type-dark-1">Product One</h5>
-            <p class="type-sm type-neutral-5 mvn">1 alert</p>
-          </div>
-        </div>
-      </a>
-    </li>
-    <li role="presentation">
-      <a role="menuitem" href="https://twitter.com/fat">
-        <div class="media man pan">
-          <div class="media-left media-middle">
-            <i class="fa fa-exclamation-triangle type-warn-2 h4 mrm"></i>
-          </div>
-          <div class="media-body media-middle">
-            <h5 class="media-heading mbn type-dark-1">Product Two</h5>
-            <p class="type-sm type-neutral-5 mvn">2 alerts</p>
-          </div>
-        </div>
-      </a>
-    </li>
-  </ul>
-</div>
-
-```
-
 */
 
-.dropdown-notifications-none {
-  width: 200px;
-  text-align: center;
-  padding: 20px;
-
-  .fa {
-    font-size: 42px;
-    padding-bottom: 7px;
-  }
-}
-
+/*** THIS IS ALL DEPRECATED CSS. REMOVE FROM HERE TO NEXT COMMENT ***/
+/*** THE NEW NOTIFICATIONS ARE FULLY FUNCTIONAL WITH THIS CSS REMOVED ***/
 .dropdown-notifications-badge {
   position: absolute;
   border-radius: 1000em;
   background-color: $brand-3;
-  text-align: center;
   color: white;
   font-size: 0.75em;
   padding: 0 4px;
-  height: 14px;
   line-height: 14px;
   top: 6px;
   right: 9px;
 }
+
 .dropdown-notifications-alert {
   position: absolute;
   top: -6px;
   right: 6px;
-}
-
-.dropdown-notifications {
-  .caret {
-    display: none;
-  }
 }
 
 .dropdown-notifications-list {
@@ -351,7 +378,66 @@ This is a notification dropdown with alerts.
     }
   }
 }
+/*** END REMOVE ***/
 
+.dropdown-notifications-none {
+  width: 200px;
+  text-align: center;
+  padding: 20px;
+
+  .fa {
+    font-size: 42px;
+    padding-bottom: 7px;
+  }
+}
+
+.dropdown-notifications {
+  .caret {
+    display: none;
+  }
+
+  .dropdown-toggle {
+    color: $notifications-bell-default-color;
+    font-size: $notifications-bell-default-size;
+
+    .dropdown-notifications-title {
+      margin: 0;
+      position: relative;
+    }
+
+    .dropdown-notifications-badge {
+      border-radius: 1000em;
+      background-color: $notifications-badge-default-bg;
+      color: white;
+      text-align: center;
+      font-weight: $notifications-badge-font-wieght;
+      padding: 0.25em;
+      line-height: 0.75em;
+      min-width: 1.25em;
+    }
+
+    .dropdown-notifications-alert, .dropdown-notifications-badge {
+      position: absolute;
+      font-size: 0.75em;
+      top: -0.2em;
+      left: 0.75em;
+      right: auto;
+    }
+  }
+
+  .dropdown-menu {
+    > li {
+      > a {
+        padding-bottom: 10px;
+      }
+      &:last-child {
+        > a {
+          padding-bottom: 0;
+        }
+      }
+    }
+  }
+}
 
 
 /*doc
@@ -371,7 +457,7 @@ Here's an example if there are no notifications:
 Here's an example if there are notifications:
 
 ```jsx_example
-var newLabel = <UI.DefaultH3><UI.Label>New</UI.Label></UI.DefaultH3>;
+var newLabel = <UI.DefaultH3 className="mvn"><UI.Label>New</UI.Label></UI.DefaultH3>;
 ```
 
 ```react_example_table

--- a/src/pivotal-ui/components/dropdowns/dropdowns.scss
+++ b/src/pivotal-ui/components/dropdowns/dropdowns.scss
@@ -216,7 +216,7 @@ This is a notification dropdown with no notifications.
   <ul class="dropdown-menu" role="menu">
     <li role="presentation">
       <div class="dropdown-notifications-none">
-        <i class="fa fa-bell type-neutral-6"></i>
+        <i class="fa fa-bell"></i>
         <p class="type-neutral-4 em-alt mbn">No notifications</p>
       </div>
     </li>
@@ -413,6 +413,7 @@ This is a notification dropdown with alerts.
   .fa {
     font-size: 42px;
     padding-bottom: 7px;
+    color: $neutral-6;
   }
 }
 

--- a/src/pivotal-ui/components/dropdowns/dropdowns.scss
+++ b/src/pivotal-ui/components/dropdowns/dropdowns.scss
@@ -276,7 +276,7 @@ This is a notification dropdown with alerts.
   <button data-toggle="dropdown" class="dropdown-toggle btn btn-link" type="button">
     <div class="dropdown-notifications-title">
       <i class="fa fa-bell"></i>
-      <i class="fa fa-exclamation-triangle dropdown-notifications-alert type-warn-2"></i>
+      <i class="fa fa-exclamation-triangle dropdown-notifications-alert"></i>
     </div>
   </button>
   <ul class="dropdown-menu" role="menu">
@@ -364,6 +364,7 @@ This is a notification dropdown with alerts.
   position: absolute;
   top: -6px;
   right: 6px;
+  color: $notifications-alert-default-color;
 }
 
 .dropdown-notifications-list {

--- a/src/pivotal-ui/components/dropdowns/package.json
+++ b/src/pivotal-ui/components/dropdowns/package.json
@@ -1,7 +1,8 @@
 {
   "homepage": "http://styleguide.pivotal.io/objects.html#dropdown",
   "dependencies": {
-    "pui-css-bootstrap": "1.9.1"
+    "pui-css-bootstrap": "1.9.1",
+    "pui-css-buttons": "1.9.1"
   },
   "version": "1.9.1"
 }

--- a/src/pivotal-ui/components/pui-variables.scss
+++ b/src/pivotal-ui/components/pui-variables.scss
@@ -498,6 +498,7 @@ $notifications-bell-default-size:     $font-size-h2;
 $notifications-bell-default-color:    $neutral-6;
 $notifications-badge-default-bg:      $brand-3;
 $notifications-badge-font-wieght:     900;
+$notifications-alert-default-color:   $warn-2;
 
 
 // COMPONENT VARIABLES

--- a/src/pivotal-ui/components/pui-variables.scss
+++ b/src/pivotal-ui/components/pui-variables.scss
@@ -492,6 +492,14 @@ $dropdown-header-color:          $gray-light !default;
 $dropdown-caret-color:           #000 !default;
 
 
+// Notifications Dropdowns
+// -------------------------
+$notifications-bell-default-size:     $font-size-h2;
+$notifications-bell-default-color:    $neutral-6;
+$notifications-badge-default-bg:      $brand-3;
+$notifications-badge-font-wieght:     900;
+
+
 // COMPONENT VARIABLES
 // --------------------------------------------------
 

--- a/src/pivotal-ui/components/typography/typography.scss
+++ b/src/pivotal-ui/components/typography/typography.scss
@@ -137,29 +137,60 @@ h4, .h4, h5, .h5, h6, .h6 {
 
 // We handle font-weight here, bootstrap handles font-size and color
 
-h1, .h1 {
+h1 {
   //If you add new h1 styles, make sure to update the h1 mixin
   font-weight: $font-weight-h1;
 }
 
-h2, .h2 {
+h2 {
   font-weight: $font-weight-h2;
 }
 
-h3, .h3 {
+h3 {
   font-weight: $font-weight-h3;
 }
 
-h4, .h4 {
+h4 {
   font-weight: $font-weight-h4;
 }
 
-h5, .h5 {
+h5 {
   font-weight: $font-weight-h5;
 }
 
-h6, .h6 {
+h6 {
   font-weight: $font-weight-h6;
+}
+
+
+.h1 {
+  font-size: $font-size-h1 !important;
+  font-weight: $font-weight-h1 !important;
+}
+
+.h2 {
+  font-size: $font-size-h2 !important;
+  font-weight: $font-weight-h2 !important;
+}
+
+.h3 {
+  font-size: $font-size-h3 !important;
+  font-weight: $font-weight-h3 !important;
+}
+
+.h4 {
+  font-size: $font-size-h4 !important;
+  font-weight: $font-weight-h4 !important;
+}
+
+.h5 {
+  font-size: $font-size-h5 !important;
+  font-weight: $font-weight-h5 !important;
+}
+
+.h6 {
+  font-size: $font-size-h6 !important;
+  font-weight: $font-weight-h6 !important;
 }
 
 small,


### PR DESCRIPTION
Lots of changes here

- Typography `.h{size}` classes now are !important, which makes the following changes possible.
- Update the notifications css component so that modifiers aren't necessary anymore
  - No need for size/color modifiers on the dropdown bell/badge
  - No need for size/color modifiers on the "no notifications" bell
  - Remove some unnecessary classes

The "legacy" way of creating notifications still works, and is marked as deprecated.