### PR TITLE
Fix: Add border on hover to DefaultAltDropdown

### DIFF
--- a/spec/pivotal-ui-react/dropdown/dropdown_spec.js
+++ b/spec/pivotal-ui-react/dropdown/dropdown_spec.js
@@ -3,7 +3,7 @@ require('../spec_helper');
 describe('Dropdowns', function() {
   describe('Dropdown', function() {
     beforeEach(function() {
-      var Dropdown = require('../../../src/pivotal-ui-react/dropdowns/dropdowns').LinkDropdown;
+      var Dropdown = require('../../../src/pivotal-ui-react/dropdowns/dropdowns').Dropdown;
       React.render(<Dropdown title="Dropping"/>, root);
     });
 
@@ -12,7 +12,11 @@ describe('Dropdowns', function() {
     });
 
     it('creates a dropdown', function() {
-      expect('button.dropdown-toggle.btn.btn-link').toContainText('Dropping');
+      expect('button.dropdown-toggle').toContainText('Dropping');
+    });
+
+    it('adds the appropriate button classes to the dropdown toggle', () => {
+      expect('button.dropdown-toggle').toHaveClass('btn-default');
     });
   });
 
@@ -27,7 +31,12 @@ describe('Dropdowns', function() {
     });
 
     it('creates a dropdown', function() {
-      expect('button.dropdown-toggle.btn.btn-link').toContainText('Dropping');
+      expect('button.dropdown-toggle').toContainText('Dropping');
+    });
+
+    it('adds the appropriate button classes to the dropdown toggle', () => {
+      expect('button.dropdown-toggle').toHaveClass('btn-link');
+      expect('button.dropdown-toggle').not.toHaveClass('btn-default');
     });
   });
 
@@ -42,7 +51,12 @@ describe('Dropdowns', function() {
     });
 
     it('creates a dropdown', function() {
-      expect('button.dropdown-toggle.btn.btn-default-alt').toContainText('Dropping');
+      expect('button.dropdown-toggle').toContainText('Dropping');
+    });
+
+    it('adds the appropriate button classes to the dropdown toggle', () => {
+      expect('button.dropdown-toggle').toHaveClass('btn-default-alt');
+      expect('button.dropdown-toggle').not.toHaveClass('btn-default');
     });
   });
 
@@ -57,8 +71,14 @@ describe('Dropdowns', function() {
     });
 
     it('creates a dropdown', function() {
-      expect('button.dropdown-toggle.btn.btn-primary').toContainText('Dropping');
+      expect('button.dropdown-toggle').toContainText('Dropping');
     });
+
+    it('adds the appropriate button classes to the dropdown toggle', () => {
+      expect('button.dropdown-toggle').toHaveClass('btn-primary');
+      expect('button.dropdown-toggle').not.toHaveClass('btn-default');
+    });
+
   });
 
   describe('LowlightDropdown', function() {
@@ -72,7 +92,13 @@ describe('Dropdowns', function() {
     });
 
     it('creates a dropdown', function() {
-      expect('button.dropdown-toggle.btn.btn-lowlight').toContainText('Dropping');
+      expect('button.dropdown-toggle').toContainText('Dropping');
+    });
+
+
+    it('adds the appropriate button classes to the dropdown toggle', () => {
+      expect('button.dropdown-toggle').toHaveClass('btn-lowlight');
+      expect('button.dropdown-toggle').not.toHaveClass('btn-default');
     });
   });
 
@@ -87,7 +113,12 @@ describe('Dropdowns', function() {
     });
 
     it('creates a dropdown', function() {
-      expect('button.dropdown-toggle.btn.btn-danger').toContainText('Dropping');
+      expect('button.dropdown-toggle').toContainText('Dropping');
+    });
+
+    it('adds the appropriate button classes to the dropdown toggle', () => {
+      expect('button.dropdown-toggle').toHaveClass('btn-danger');
+      expect('button.dropdown-toggle').not.toHaveClass('btn-default');
     });
   });
 
@@ -102,7 +133,12 @@ describe('Dropdowns', function() {
     });
 
     it('creates a dropdown', function() {
-      expect('button.dropdown-toggle.btn.btn-highlight').toContainText('Dropping');
+      expect('button.dropdown-toggle').toContainText('Dropping');
+    });
+
+    it('adds the appropriate button classes to the dropdown toggle', () => {
+      expect('button.dropdown-toggle').toHaveClass('btn-highlight');
+      expect('button.dropdown-toggle').not.toHaveClass('btn-default');
     });
   });
 
@@ -117,7 +153,12 @@ describe('Dropdowns', function() {
     });
 
     it('creates a dropdown', function() {
-      expect('button.dropdown-toggle.btn.btn-highlight-alt').toContainText('Dropping');
+      expect('button.dropdown-toggle').toContainText('Dropping');
+    });
+
+    it('adds the appropriate button classes to the dropdown toggle', () => {
+      expect('button.dropdown-toggle').toHaveClass('btn-highlight-alt');
+      expect('button.dropdown-toggle').not.toHaveClass('btn-default');
     });
   });
 });

--- a/spec/pivotal-ui-react/dropdown/dropdown_spec.js
+++ b/spec/pivotal-ui-react/dropdown/dropdown_spec.js
@@ -1,6 +1,28 @@
 require('../spec_helper');
 
 describe('Dropdowns', function() {
+  function dropdownTestFor(dropdownComponentName, dropdownClassName) {
+    describe(dropdownComponentName, function() {
+      beforeEach(function() {
+        var DropdownClass = require('../../../src/pivotal-ui-react/dropdowns/dropdowns')[dropdownComponentName];
+        React.render(<DropdownClass title="Dropping"/>, root);
+      });
+
+      afterEach(function() {
+        React.unmountComponentAtNode(root);
+      });
+
+      it('creates a dropdown', function() {
+        expect('button.dropdown-toggle').toContainText('Dropping');
+      });
+
+      it('adds the appropriate button classes to the dropdown toggle', () => {
+        expect('button.dropdown-toggle').toHaveClass(dropdownClassName);
+        expect('button.dropdown-toggle').not.toHaveClass('btn-default');
+      });
+    });
+  }
+
   describe('Dropdown', function() {
     beforeEach(function() {
       var Dropdown = require('../../../src/pivotal-ui-react/dropdowns/dropdowns').Dropdown;
@@ -20,145 +42,17 @@ describe('Dropdowns', function() {
     });
   });
 
-  describe('LinkDropdown', function() {
-    beforeEach(function() {
-      var LinkDropdown = require('../../../src/pivotal-ui-react/dropdowns/dropdowns').LinkDropdown;
-      React.render(<LinkDropdown title="Dropping"/>, root);
-    });
+  dropdownTestFor('LinkDropdown', 'btn-link');
 
-    afterEach(function() {
-      React.unmountComponentAtNode(root);
-    });
+  dropdownTestFor('DefaultAltDropdown', 'btn-default-alt');
 
-    it('creates a dropdown', function() {
-      expect('button.dropdown-toggle').toContainText('Dropping');
-    });
+  dropdownTestFor('PrimaryDropdown', 'btn-primary');
 
-    it('adds the appropriate button classes to the dropdown toggle', () => {
-      expect('button.dropdown-toggle').toHaveClass('btn-link');
-      expect('button.dropdown-toggle').not.toHaveClass('btn-default');
-    });
-  });
+  dropdownTestFor('LowlightDropdown', 'btn-lowlight');
 
-  describe('DefaultAltDropdown', function() {
-    beforeEach(function() {
-      var DefaultAltDropdown = require('../../../src/pivotal-ui-react/dropdowns/dropdowns').DefaultAltDropdown;
-      React.render(<DefaultAltDropdown title="Dropping"/>, root);
-    });
+  dropdownTestFor('DangerDropdown', 'btn-danger');
 
-    afterEach(function() {
-      React.unmountComponentAtNode(root);
-    });
+  dropdownTestFor('HighlightDropdown', 'btn-highlight');
 
-    it('creates a dropdown', function() {
-      expect('button.dropdown-toggle').toContainText('Dropping');
-    });
-
-    it('adds the appropriate button classes to the dropdown toggle', () => {
-      expect('button.dropdown-toggle').toHaveClass('btn-default-alt');
-      expect('button.dropdown-toggle').not.toHaveClass('btn-default');
-    });
-  });
-
-  describe('PrimaryDropdown', function() {
-    beforeEach(function() {
-      var PrimaryDropdown = require('../../../src/pivotal-ui-react/dropdowns/dropdowns').PrimaryDropdown;
-      React.render(<PrimaryDropdown title="Dropping"/>, root);
-    });
-
-    afterEach(function() {
-      React.unmountComponentAtNode(root);
-    });
-
-    it('creates a dropdown', function() {
-      expect('button.dropdown-toggle').toContainText('Dropping');
-    });
-
-    it('adds the appropriate button classes to the dropdown toggle', () => {
-      expect('button.dropdown-toggle').toHaveClass('btn-primary');
-      expect('button.dropdown-toggle').not.toHaveClass('btn-default');
-    });
-
-  });
-
-  describe('LowlightDropdown', function() {
-    beforeEach(function() {
-      var LowlightDropdown = require('../../../src/pivotal-ui-react/dropdowns/dropdowns').LowlightDropdown;
-      React.render(<LowlightDropdown title="Dropping"/>, root);
-    });
-
-    afterEach(function() {
-      React.unmountComponentAtNode(root);
-    });
-
-    it('creates a dropdown', function() {
-      expect('button.dropdown-toggle').toContainText('Dropping');
-    });
-
-
-    it('adds the appropriate button classes to the dropdown toggle', () => {
-      expect('button.dropdown-toggle').toHaveClass('btn-lowlight');
-      expect('button.dropdown-toggle').not.toHaveClass('btn-default');
-    });
-  });
-
-  describe('DangerDropdown', function() {
-    beforeEach(function() {
-      var DangerDropdown = require('../../../src/pivotal-ui-react/dropdowns/dropdowns').DangerDropdown;
-      React.render(<DangerDropdown title="Dropping"/>, root);
-    });
-
-    afterEach(function() {
-      React.unmountComponentAtNode(root);
-    });
-
-    it('creates a dropdown', function() {
-      expect('button.dropdown-toggle').toContainText('Dropping');
-    });
-
-    it('adds the appropriate button classes to the dropdown toggle', () => {
-      expect('button.dropdown-toggle').toHaveClass('btn-danger');
-      expect('button.dropdown-toggle').not.toHaveClass('btn-default');
-    });
-  });
-
-  describe('HighlightDropdown', function() {
-    beforeEach(function() {
-      var HighlightDropdown = require('../../../src/pivotal-ui-react/dropdowns/dropdowns').HighlightDropdown;
-      React.render(<HighlightDropdown title="Dropping"/>, root);
-    });
-
-    afterEach(function() {
-      React.unmountComponentAtNode(root);
-    });
-
-    it('creates a dropdown', function() {
-      expect('button.dropdown-toggle').toContainText('Dropping');
-    });
-
-    it('adds the appropriate button classes to the dropdown toggle', () => {
-      expect('button.dropdown-toggle').toHaveClass('btn-highlight');
-      expect('button.dropdown-toggle').not.toHaveClass('btn-default');
-    });
-  });
-
-  describe('HighlightAltDropdown', function() {
-    beforeEach(function() {
-      var HighlightAltDropdown = require('../../../src/pivotal-ui-react/dropdowns/dropdowns').HighlightAltDropdown;
-      React.render(<HighlightAltDropdown title="Dropping"/>, root);
-    });
-
-    afterEach(function() {
-      React.unmountComponentAtNode(root);
-    });
-
-    it('creates a dropdown', function() {
-      expect('button.dropdown-toggle').toContainText('Dropping');
-    });
-
-    it('adds the appropriate button classes to the dropdown toggle', () => {
-      expect('button.dropdown-toggle').toHaveClass('btn-highlight-alt');
-      expect('button.dropdown-toggle').not.toHaveClass('btn-default');
-    });
-  });
+  dropdownTestFor('HighlightAltDropdown', 'btn-highlight-alt');
 });

--- a/src/pivotal-ui-react/dropdowns/dropdowns.js
+++ b/src/pivotal-ui-react/dropdowns/dropdowns.js
@@ -69,7 +69,7 @@ module.exports = {
    * @see [Pivotal UI React](http://styleguide.pivotal.io/react_beta.html#dropdown_react)
    * @see [Pivotal UI CSS](http://styleguide.pivotal.io/objects.html#dropdown)
    */
-  DefaultAltDropdown: defDropdown({buttonClassName: 'btn-default-alt'}),
+  DefaultAltDropdown: defDropdown({buttonClassName: 'btn-default-alt', bsStyle: null}),
 
   /**
    * @component PrimaryDropdown
@@ -91,7 +91,7 @@ module.exports = {
    * @see [Pivotal UI React](http://styleguide.pivotal.io/react_beta.html#dropdown_react)
    * @see [Pivotal UI CSS](http://styleguide.pivotal.io/objects.html#dropdown)
    */
-  LowlightDropdown: defDropdown({buttonClassName: 'btn-lowlight'}),
+  LowlightDropdown: defDropdown({buttonClassName: 'btn-lowlight', bsStyle: null}),
 
   /**
    * @component DangerDropdown
@@ -113,7 +113,7 @@ module.exports = {
    * @see [Pivotal UI React](http://styleguide.pivotal.io/react_beta.html#dropdown_react)
    * @see [Pivotal UI CSS](http://styleguide.pivotal.io/objects.html#dropdown)
    */
-  HighlightDropdown: defDropdown({buttonClassName: 'btn-highlight'}),
+  HighlightDropdown: defDropdown({buttonClassName: 'btn-highlight', bsStyle: null}),
 
   /**
    * @component HighlightAltDropdown
@@ -124,5 +124,5 @@ module.exports = {
    * @see [Pivotal UI React](http://styleguide.pivotal.io/react_beta.html#dropdown_react)
    * @see [Pivotal UI CSS](http://styleguide.pivotal.io/objects.html#dropdown)
    */
-  HighlightAltDropdown: defDropdown({buttonClassName: 'btn-highlight-alt'})
+  HighlightAltDropdown: defDropdown({buttonClassName: 'btn-highlight-alt', bsStyle: null})
 };


### PR DESCRIPTION
React-bootstrap was adding the `btn-default` to the `DefaultAltDropdown` which was overriding styles. It was also adding that class to the `LowlightDropdown`, `HighlightDropdown`, and `HighlightAltDropdown`. This PR removes the `btn-default` class from those dropdowns.