### PR TITLE
fix(sortable-table): refactor sortable-table to rerender with data change

### DIFF
--- a/spec/pivotal-ui-react/sortable-table/sortable-table_spec.js
+++ b/spec/pivotal-ui-react/sortable-table/sortable-table_spec.js
@@ -1,46 +1,54 @@
 require('../spec_helper');
+import {SortableTable, TableCell, TableHeader, TableRow} from '../../../src/pivotal-ui-react/sortable-table/sortable-table';
+
 describe('SortableTable', function() {
-  var SortableTable, data, columns;
-  beforeEach(function() {
-    SortableTable = require('../../../src/pivotal-ui-react/sortable-table/sortable-table').SortableTable;
-    columns = [
-      {
-        name: 'title',
-        title: 'Title',
-        sortable: true
-      },
-      {
-        name: 'instances',
-        title: 'Instances',
-        sortable: true,
-        align: 'center'
-      },
-      {
-        name: 'unsortable',
-        title: 'Unsortable',
-        sortable: false,
-        align: 'right'
-      }
-    ];
-    data = [
-      {
-        instances: '1',
-        title: 'foo',
-        unsortable: '14'
-      },
-      {
-        instances: '3',
-        title: 'sup',
-        unsortable: '22'
-      },
-      {
-        title: 'yee',
-        instances: '2',
-        unsortable: '1'
-      }
+  var headers, clickSpy;
+
+  const data = [
+    {
+      instances: '1',
+      title: 'foo',
+      unsortable: '14'
+    },
+    {
+      instances: '3',
+      title: 'sup',
+      unsortable: '22'
+    },
+    {
+      title: 'yee',
+      instances: '2',
+      unsortable: '1'
+    }
+  ];
+
+  function renderSortableTable(data, props = {}) {
+    clickSpy = jasmine.createSpy('click');
+    headers = [
+      <TableHeader sortable={true} onClick={clickSpy}>Title</TableHeader>,
+      <TableHeader sortable={true}>Instances</TableHeader>,
+      <TableHeader>Unsortable</TableHeader>
     ];
 
-    React.render(<SortableTable {...{data, columns}}/>, root);
+    React.render((
+        <SortableTable headers={headers} {...props}>
+          {data.map(function(datum, key) {
+            return (
+              <TableRow key={key}>
+                <TableCell>{datum.title}</TableCell>
+                <TableCell>{datum.instances}</TableCell>
+                <TableCell>{datum.unsortable}</TableCell>
+              </TableRow>
+            );
+          })}
+        </SortableTable>
+      ),
+      root
+    );
+  }
+
+  beforeEach(function() {
+    renderSortableTable(data);
   });
 
   afterEach(function() {
@@ -53,18 +61,13 @@ describe('SortableTable', function() {
     expect('th:contains("Unsortable")').not.toHaveClass('sortable');
   });
 
-  it('adds the additional classes specified in the "classes" property', function() {
-    React.render(<SortableTable {...{data, columns, classes: ['table-light']}}/>, root);
-
+  it('adds the additional classes, id and styles to the table', function() {
+    renderSortableTable(data, {className: ['table-light'], id: 'table-id', style: {opacity: '0.5'}});
     expect('table.table-sortable').toHaveClass('table');
     expect('table.table-sortable').toHaveClass('table-sortable');
     expect('table.table-sortable').toHaveClass('table-light');
-  });
-
-  it('column data is aligned to the specified margin', function() {
-    expect('tbody tr:nth-of-type(1) > td:eq(0)').not.toHaveClass('txt-l');
-    expect('tbody tr:nth-of-type(2) > td:eq(1)').toHaveClass('txt-c');
-    expect('tbody tr:nth-of-type(1) > td:eq(2)').toHaveClass('txt-r');
+    expect('table.table-sortable').toHaveProp('id', 'table-id');
+    expect('table.table-sortable').toHaveCss({opacity: '0.5'});
   });
 
   it('sorts table rows by the first column in ascending order by default', function() {
@@ -79,9 +82,13 @@ describe('SortableTable', function() {
     expect('tbody tr:nth-of-type(3) > td:eq(1)').toContainText('2');
   });
 
-  describe('clicking on the already asc-sorted column', function() {
+  describe('clicking on the already asc-sorted column that has an existing onClick function', function() {
     beforeEach(function() {
       $('th:contains("Title")').simulate('click');
+    });
+
+    it('calls the onClick function', function() {
+      expect(clickSpy).toHaveBeenCalled();
     });
 
     it('reverses the sort order', function() {
@@ -98,7 +105,12 @@ describe('SortableTable', function() {
 
     describe('clicking on the already desc-sorted column', function() {
       beforeEach(function() {
+        clickSpy.calls.reset();
         $('th:contains("Title")').simulate('click');
+      });
+
+      it('calls the onClick function', function() {
+        expect(clickSpy).toHaveBeenCalled();
       });
 
       it('reverses the sort order', function() {
@@ -152,5 +164,161 @@ describe('SortableTable', function() {
       expect('tbody tr:nth-of-type(3) > td:eq(1)').toContainText('2');
     });
   });
+
+  describe('when the rows change', function() {
+    beforeEach(function() {
+      var newData = data.concat({
+        title: 'new title',
+        instances: '3',
+        unsortable: '1'
+      });
+      renderSortableTable(newData);
+    });
+
+    it('shows the new rows in the correct sort order', function() {
+      expect('tbody tr').toHaveLength(4);
+      var titles = $('tbody tr > td:first-child').map(function() {return $(this).text(); }).toArray();
+      expect(titles).toEqual(['foo', 'new title', 'sup', 'yee']);
+    });
+  });
 });
 
+describe('TableHeader', function() {
+  function renderTableHeader({children, ...props}) {
+    return React.render((
+        <table>
+          <thead>
+            <tr>
+              <TableHeader {...props}>
+                {children}
+              </TableHeader>
+            </tr>
+          </thead>
+        </table>
+      ), root
+    );
+
+  }
+
+  it('contains the given children', function() {
+    renderTableHeader({children: (<p id={'header-id'}></p>)});
+    expect('th').toExist();
+    expect('th > p#header-id').toExist();
+  });
+
+  describe('when the header is sortable', function() {
+    const props = {
+      sortable: true,
+      id: 'header-id',
+      className: 'header-light',
+      style: {opacity: '0.5'}
+    };
+
+    it('adds the additional classes, id and styles to the th', function() {
+      renderTableHeader(props);
+      expect('th').toHaveClass('sortable');
+      expect('th').toHaveClass('header-light');
+      expect('th').toHaveProp('id', 'header-id');
+      expect('th').toHaveCss({opacity: '0.5'});
+    });
+
+    describe('when there is an onSortableTableHeaderClick provided', function() {
+      var onSortableTableHeaderClickSpy;
+      beforeEach(function() {
+        onSortableTableHeaderClickSpy = jasmine.createSpy('onSortableTableHeaderClick');
+        renderTableHeader({onSortableTableHeaderClick: onSortableTableHeaderClickSpy, ...props});
+      });
+
+      describe('when clicking on the table header', function() {
+        it('calls the callback', function() {
+          $('th').simulate('click');
+          expect(onSortableTableHeaderClickSpy).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe('when the header is not sortable', function() {
+    it('adds the additional classes, id and styles to the th', function() {
+      renderTableHeader({
+        sortable: false,
+        id: 'header-id',
+        className: 'header-light',
+        style: {opacity: '0.5'}
+      });
+      expect('th').not.toHaveClass('sortable');
+      expect('th').toHaveClass('header-light');
+      expect('th').toHaveProp('id', 'header-id');
+      expect('th').toHaveCss({opacity: '0.5'});
+    });
+  });
+});
+
+describe('TableRow', function() {
+  function renderTableRow({children=(<td></td>), ...props}) {
+    return React.render((
+        <table>
+          <tbody>
+            <TableRow {...props}>
+              {children}
+            </TableRow>
+          </tbody>
+        </table>
+      ), root
+    );
+
+  }
+  it('contains the given children', function() {
+    renderTableRow({children: (<td id={'cell-id'}></td>)});
+    expect('tr').toExist();
+    expect('tr > td#cell-id').toExist();
+  });
+
+
+  it('adds the additional classes, id and styles to the th', function() {
+    renderTableRow({
+      id: 'row-id',
+      className: 'row-light',
+      style: {opacity: '0.5'}
+    });
+    expect('tr').toHaveClass('row-light');
+    expect('tr').toHaveProp('id', 'row-id');
+    expect('tr').toHaveCss({opacity: '0.5'});
+  });
+});
+
+describe('TableCell', function() {
+  function renderTableCell({children, ...props}) {
+    return React.render((
+        <table>
+          <tbody>
+            <tr>
+              <TableCell {...props}>
+                {children}
+              </TableCell>
+            </tr>
+          </tbody>
+        </table>
+      ), root
+    );
+
+  }
+
+  it('contains the given children', function() {
+    renderTableCell({children: (<p>This is my text</p>)});
+    expect('td').toExist();
+    expect('td > p').toExist();
+    expect('td > p').toContainText('This is my text');
+  });
+
+  it('adds the additional classes, id and styles to the th', function() {
+    renderTableCell({
+      id: 'cell-id',
+      className: 'cell-light',
+      style: {opacity: '0.5'}
+    });
+    expect('td').toHaveClass('cell-light');
+    expect('td').toHaveProp('id', 'cell-id');
+    expect('td').toHaveCss({opacity: '0.5'});
+  });
+});

--- a/spec/pivotal-ui-react/sortable-table/sortable-table_spec.js
+++ b/spec/pivotal-ui-react/sortable-table/sortable-table_spec.js
@@ -7,17 +7,20 @@ describe('SortableTable', function() {
   const data = [
     {
       instances: '1',
+      bar: '9',
       title: 'foo',
       unsortable: '14'
     },
     {
       instances: '3',
+      bar: '7',
       title: 'sup',
       unsortable: '22'
     },
     {
       title: 'yee',
       instances: '2',
+      bar: '8',
       unsortable: '1'
     }
   ];
@@ -25,8 +28,9 @@ describe('SortableTable', function() {
   function renderSortableTable(data, props = {}) {
     clickSpy = jasmine.createSpy('click');
     headers = [
-      <TableHeader sortable={true} onClick={clickSpy}>Title</TableHeader>,
-      <TableHeader sortable={true}>Instances</TableHeader>,
+      <TableHeader>Title</TableHeader>,
+      <TableHeader onClick={clickSpy} sortable={true}>Instances</TableHeader>,
+      <TableHeader sortable={true}>Bar</TableHeader>,
       <TableHeader>Unsortable</TableHeader>
     ];
 
@@ -37,6 +41,7 @@ describe('SortableTable', function() {
               <TableRow key={key}>
                 <TableCell>{datum.title}</TableCell>
                 <TableCell>{datum.instances}</TableCell>
+                <TableCell>{datum.bar}</TableCell>
                 <TableCell>{datum.unsortable}</TableCell>
               </TableRow>
             );
@@ -56,7 +61,7 @@ describe('SortableTable', function() {
   });
 
   it('adds the class "sortable" on all sortable columns', function() {
-    expect('th:contains("Title")').toHaveClass('sortable');
+    expect('th:contains("Title")').not.toHaveClass('sortable');
     expect('th:contains("Instances")').toHaveClass('sortable');
     expect('th:contains("Unsortable")').not.toHaveClass('sortable');
   });
@@ -70,21 +75,21 @@ describe('SortableTable', function() {
     expect('table.table-sortable').toHaveCss({opacity: '0.5'});
   });
 
-  it('sorts table rows by the first column in ascending order by default', function() {
-    expect('th:contains("Title")').toHaveClass('sorted-asc');
+  it('sorts table rows by the first sortable column in ascending order by default', function() {
+    expect('th:contains("Instances")').toHaveClass('sorted-asc');
 
     expect('tbody tr:nth-of-type(1) > td:eq(0)').toContainText('foo');
-    expect('tbody tr:nth-of-type(2) > td:eq(0)').toContainText('sup');
-    expect('tbody tr:nth-of-type(3) > td:eq(0)').toContainText('yee');
+    expect('tbody tr:nth-of-type(2) > td:eq(0)').toContainText('yee');
+    expect('tbody tr:nth-of-type(3) > td:eq(0)').toContainText('sup');
 
     expect('tbody tr:nth-of-type(1) > td:eq(1)').toContainText('1');
-    expect('tbody tr:nth-of-type(2) > td:eq(1)').toContainText('3');
-    expect('tbody tr:nth-of-type(3) > td:eq(1)').toContainText('2');
+    expect('tbody tr:nth-of-type(2) > td:eq(1)').toContainText('2');
+    expect('tbody tr:nth-of-type(3) > td:eq(1)').toContainText('3');
   });
 
   describe('clicking on the already asc-sorted column that has an existing onClick function', function() {
     beforeEach(function() {
-      $('th:contains("Title")').simulate('click');
+      $('th:contains("Instances")').simulate('click');
     });
 
     it('calls the onClick function', function() {
@@ -92,21 +97,21 @@ describe('SortableTable', function() {
     });
 
     it('reverses the sort order', function() {
-      expect('th:contains("Title")').toHaveClass('sorted-desc');
+      expect('th:contains("Instances")').toHaveClass('sorted-desc');
 
-      expect('tbody tr:nth-of-type(1) > td:eq(0)').toContainText('yee');
-      expect('tbody tr:nth-of-type(2) > td:eq(0)').toContainText('sup');
+      expect('tbody tr:nth-of-type(1) > td:eq(0)').toContainText('sup');
+      expect('tbody tr:nth-of-type(2) > td:eq(0)').toContainText('yee');
       expect('tbody tr:nth-of-type(3) > td:eq(0)').toContainText('foo');
 
-      expect('tbody tr:nth-of-type(1) > td:eq(1)').toContainText('2');
-      expect('tbody tr:nth-of-type(2) > td:eq(1)').toContainText('3');
+      expect('tbody tr:nth-of-type(1) > td:eq(1)').toContainText('3');
+      expect('tbody tr:nth-of-type(2) > td:eq(1)').toContainText('2');
       expect('tbody tr:nth-of-type(3) > td:eq(1)').toContainText('1');
     });
 
     describe('clicking on the already desc-sorted column', function() {
       beforeEach(function() {
         clickSpy.calls.reset();
-        $('th:contains("Title")').simulate('click');
+        $('th:contains("Instances")').simulate('click');
       });
 
       it('calls the onClick function', function() {
@@ -114,27 +119,46 @@ describe('SortableTable', function() {
       });
 
       it('reverses the sort order', function() {
-        expect('th:contains("Title")').toHaveClass('sorted-asc');
+        expect('th:contains("Instances")').toHaveClass('sorted-asc');
 
         expect('tbody tr:nth-of-type(1) > td:eq(0)').toContainText('foo');
-        expect('tbody tr:nth-of-type(2) > td:eq(0)').toContainText('sup');
-        expect('tbody tr:nth-of-type(3) > td:eq(0)').toContainText('yee');
+        expect('tbody tr:nth-of-type(2) > td:eq(0)').toContainText('yee');
+        expect('tbody tr:nth-of-type(3) > td:eq(0)').toContainText('sup');
 
         expect('tbody tr:nth-of-type(1) > td:eq(1)').toContainText('1');
-        expect('tbody tr:nth-of-type(2) > td:eq(1)').toContainText('3');
-        expect('tbody tr:nth-of-type(3) > td:eq(1)').toContainText('2');
+        expect('tbody tr:nth-of-type(2) > td:eq(1)').toContainText('2');
+        expect('tbody tr:nth-of-type(3) > td:eq(1)').toContainText('3');
       });
     });
   });
 
   describe('clicking on a sortable column', function() {
     beforeEach(function() {
-      $('th:contains("Instances")').simulate('click');
+      $('th:contains("Bar")').simulate('click');
     });
 
     it('sorts table rows by that column', function() {
-      expect('th:contains("Instances")').toHaveClass('sorted-asc');
+      expect('th:contains("Bar")').toHaveClass('sorted-asc');
       expect('th:contains("Title")').not.toHaveClass('sorted-asc');
+
+      expect('tbody tr:nth-of-type(1) > td:eq(0)').toContainText('sup');
+      expect('tbody tr:nth-of-type(2) > td:eq(0)').toContainText('yee');
+      expect('tbody tr:nth-of-type(3) > td:eq(0)').toContainText('foo');
+
+      expect('tbody tr:nth-of-type(1) > td:eq(2)').toContainText('7');
+      expect('tbody tr:nth-of-type(2) > td:eq(2)').toContainText('8');
+      expect('tbody tr:nth-of-type(3) > td:eq(2)').toContainText('9');
+    });
+  });
+
+  describe('clicking on a non-sortable column', function() {
+    beforeEach(function() {
+      $('th:contains("Unsortable")').simulate('click');
+    });
+
+    it('does not change the sort', function() {
+      expect('th:contains("Unsortable")').not.toHaveClass('sorted-asc');
+      expect('th:contains("Instances")').toHaveClass('sorted-asc');
 
       expect('tbody tr:nth-of-type(1) > td:eq(0)').toContainText('foo');
       expect('tbody tr:nth-of-type(2) > td:eq(0)').toContainText('yee');
@@ -146,39 +170,21 @@ describe('SortableTable', function() {
     });
   });
 
-  describe('clicking on a non-sortable column', function() {
-    beforeEach(function() {
-      $('th:contains("Unsortable")').simulate('click');
-    });
-
-    it('does not change the sort', function() {
-      expect('th:contains("Unsortable")').not.toHaveClass('sorted-asc');
-      expect('th:contains("Title")').toHaveClass('sorted-asc');
-
-      expect('tbody tr:nth-of-type(1) > td:eq(0)').toContainText('foo');
-      expect('tbody tr:nth-of-type(2) > td:eq(0)').toContainText('sup');
-      expect('tbody tr:nth-of-type(3) > td:eq(0)').toContainText('yee');
-
-      expect('tbody tr:nth-of-type(1) > td:eq(1)').toContainText('1');
-      expect('tbody tr:nth-of-type(2) > td:eq(1)').toContainText('3');
-      expect('tbody tr:nth-of-type(3) > td:eq(1)').toContainText('2');
-    });
-  });
-
   describe('when the rows change', function() {
     beforeEach(function() {
       var newData = data.concat({
         title: 'new title',
-        instances: '3',
-        unsortable: '1'
+        instances: '1.5',
+        unsortable: '1',
+        bar: '123'
       });
       renderSortableTable(newData);
     });
 
     it('shows the new rows in the correct sort order', function() {
       expect('tbody tr').toHaveLength(4);
-      var titles = $('tbody tr > td:first-child').map(function() {return $(this).text(); }).toArray();
-      expect(titles).toEqual(['foo', 'new title', 'sup', 'yee']);
+      var instances = $('tbody tr > td:nth-of-type(2)').map(function() {return $(this).text(); }).toArray();
+      expect(instances).toEqual(['1', '1.5', '2', '3']);
     });
   });
 });

--- a/src/pivotal-ui-react/sortable-table/sortable-table.js
+++ b/src/pivotal-ui-react/sortable-table/sortable-table.js
@@ -1,6 +1,8 @@
 const classnames = require('classnames');
 const React = require('react');
 const sortBy = require('lodash.sortby');
+import {mergeProps} from '../../../src/pivotal-ui-react/helpers/helpers';
+
 
 const types = React.PropTypes;
 
@@ -96,7 +98,11 @@ export const SortableTable = React.createClass({
   },
 
   getInitialState() {
-    return {sortColumn: 0, sortAscending: true};
+    const sortCol = this.props.headers.findIndex((header) => {
+      return header.props.sortable;
+    });
+    // If none of the columns are sortable we default to the 0th column
+    return {sortColumn: sortCol === -1 ? 0 : sortCol, sortAscending: true};
   },
 
   setSortedColumn(sortColumn, sortAscending) {
@@ -138,11 +144,11 @@ export const SortableTable = React.createClass({
   },
 
   render() {
-    let {className, style, id} = this.props;
+    const props = mergeProps(this.props, {className: ['table', 'table-sortable']});
     let rows = this.sortedRows();
 
     return (
-      <table className={classnames('table', 'table-sortable', className)} id={id} style={style} >
+      <table {...props} >
         <thead>
           <tr>{this.renderHeaders()}</tr>
         </thead>

--- a/src/pivotal-ui/components/tables/tables.scss
+++ b/src/pivotal-ui/components/tables/tables.scss
@@ -335,51 +335,21 @@ functioning sort.
 The `SortableTable` expects the following properties:
 
 
-Property  | Type                             | Description
-----------| ---------------------------------| --------------------------------------------------------------------------
-`data`    | Array of JS objects              | The collection of data to be displayed
-`columns` | Array of column objects          | Informs the table how to render columns as well as which columns should be sortable
-`classes` | Array of strings                 | A list of class names to be added to the table element
+Property   | Required? | Type                             | Description
+-----------| ----------| ---------------------------------| --------------------------------------------------------------------------
+`headers`  | **yes**   | Array of TableHeader components  | The headers to display in the desired order
 
+The `TableHeader` objects should have the following structure:
 
-The column objects should have the following structure:
+Property   | Required? | Type             | Description
+-----------| ----------|------------------| --------------------------------------------------------------------------
+`sortable` | no        | Boolean          | Is this column sortable? Defaults to false
 
-Property   | Required? | Type                         | Description
------------| ----------|------------------------------| --------------------------------------------------------------------------
-`name`     | **yes**   | String                       | Name of the property on a data object (how to lookup the value for this column)
-`title`    | **yes**   | String                       | Name to display on the table header
-`sortable` | no        | Boolean                      | Is this column sortable? Defaults to false
-`align`    | no        | 'center', 'left', or 'right' | How should text be aligned within this column? Defaults to left
 
 If a column is marked as being sortable, it will attempt to sort the values as strings.
 
 
-```js_example
-var sortTableCols = [
-  {
-    name: 'name',
-    title: 'Name',
-    sortable: true
-  },
-  {
-    name: 'instances',
-    title: 'Instances',
-    sortable: true,
-    align: 'center'
-  },
-  {
-    name: 'cpu',
-    title: 'CPU',
-    sortable: true,
-    align: 'right'
-  },
-  {
-    name: 'synergy',
-    title: 'Synergy',
-    align: 'left'
-  }
-]
-
+```jsx_example
 var sortTableData = [
   {
     instances: '1',
@@ -411,9 +381,24 @@ var sortTableData = [
 
 ```react_example
 <UI.SortableTable
-  data={sortTableData}
-  columns={sortTableCols}
-  classes={['table-data', 'table-light']} />
+  headers={[
+  <UI.TableHeader sortable={true}>Name</UI.TableHeader>,
+  <UI.TableHeader sortable={true}>Instances</UI.TableHeader>,
+  <UI.TableHeader sortable={true}>CPU</UI.TableHeader>,
+  <UI.TableHeader>Synergy</UI.TableHeader>,
+  ]}
+  className="table-light">
+  {sortTableData.map(function(datum, key) {
+    return (
+      <UI.TableRow key={key}>
+        <UI.TableCell>{datum.name}</UI.TableCell>
+        <UI.TableCell>{datum.instances}</UI.TableCell>
+        <UI.TableCell>{datum.cpu}</UI.TableCell>
+        <UI.TableCell>{datum.synergy}</UI.TableCell>
+      </UI.TableRow>
+    );
+  })}
+</UI.SortableTable>
 ```
 
 */

--- a/src/pivotal-ui/javascripts/components.js
+++ b/src/pivotal-ui/javascripts/components.js
@@ -1,7 +1,5 @@
-
+var sortableTable = require('pui-react-sortable-table');
 module.exports = {
-  SortableTable: require('pui-react-sortable-table').SortableTable,
-
   DefaultH1: require('pui-react-typography').DefaultH1,
   DefaultH2: require('pui-react-typography').DefaultH2,
   DefaultH3: require('pui-react-typography').DefaultH3,
@@ -120,5 +118,4 @@ module.exports = {
   BackToTop: require('pui-react-back-to-top').BackToTop,
 
   PortalSource: require('pui-react-portals').PortalSource,
-  PortalDestination: require('pui-react-portals').PortalDestination
-};
+  PortalDestination: require('pui-react-portals').PortalDestination, ...sortableTable};

--- a/src/pivotal-ui/javascripts/components.js
+++ b/src/pivotal-ui/javascripts/components.js
@@ -118,4 +118,5 @@ module.exports = {
   BackToTop: require('pui-react-back-to-top').BackToTop,
 
   PortalSource: require('pui-react-portals').PortalSource,
-  PortalDestination: require('pui-react-portals').PortalDestination, ...sortableTable};
+  PortalDestination: require('pui-react-portals').PortalDestination,
+  ...sortableTable};


### PR DESCRIPTION
New interface for sortable-table, which also fixes the bug where the
table didn't rerender when the data changed.

[Finishes #97658788]

BREAKING CHANGE: (javascript) React component has new wrapping components for
the header and rows.