### PR TITLE
feat(bootstrap): lockdown peer dependency of bootstrap version

### DIFF
--- a/src/pivotal-ui/components/bootstrap/package.json
+++ b/src/pivotal-ui/components/bootstrap/package.json
@@ -1,5 +1,8 @@
 {
   "version": "1.10.0",
   "description": "Custom build of Bootstrap for Pivotal UI",
-  "homepage": "http://styleguide.pivotal.io/"
+  "homepage": "http://styleguide.pivotal.io/",
+  "peerDependencies": {
+    "bootstrap": "3.3.5"
+  }
 }


### PR DESCRIPTION
bootstrap peer dependency locked down to version 3.3.5

[Finishes #98028534]