### PR TITLE
Getting started docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # pivotal-ui
 [![Build Status](https://travis-ci.org/pivotal-cf/pivotal-ui.svg)](https://travis-ci.org/pivotal-cf/pivotal-ui)
 
-***
 
 Pivotal UI includes Pivotal styles as well as Bootstrap CSS, OOCSS, FontAwesome icons fonts, and the Source Sans Pro Google Font in your project. This is everything you need to get started building UI at Pivotal.
 
@@ -11,7 +10,6 @@ To contribute, see the [contributing readme](CONTRIBUTING.md).
 
 [Visit the live styleguide](http://styleguide.pivotal.io)  
 
-***
 
 # Using Pivotal UI on your project (with React)
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ To contribute, see the [contributing readme](CONTRIBUTING.md).
 
 If you're ready to try PUI with React, follow these instructions!
 
-***
-
-**NB** - We're assuming that you have the following setup on your project:
+1. We're assuming that you have the following setup on your project:
 
   - **Browserify or Webpack** - Our React modules follow the CommonJS module
     pattern. You will need to use [Browserify](http://browserify.org/) or

--- a/README.md
+++ b/README.md
@@ -68,13 +68,12 @@ If you're ready to try PUI with React, follow these instructions!
    <html>
      <head>
        <title>...</title>
-       <script src="<path-to-your-project's-compiled-javascript-file>"></script>
-
        <link rel="stylesheet" href="<path-to-your-asset-build-folder>/components.css">
 
      </head>
      <body>
        <!-- ... -->
+       <script src="<path-to-your-project's-compiled-javascript-file>"></script>
      </body>
    </html>
    ```
@@ -114,6 +113,9 @@ If you're ready to try PUI with React, follow these instructions!
    <!-- ... -->
    <body>
      <div id="root"></div>
+  
+     <!-- Script tag should be below all DOM elements -->
+     <script src="<path-to-your-project's-compiled-javascript-file>"></script>
    </body>
    <!-- ... -->
    ```

--- a/README.md
+++ b/README.md
@@ -5,23 +5,11 @@
 
 Pivotal UI includes Pivotal styles as well as Bootstrap CSS, OOCSS, FontAwesome icons fonts, and the Source Sans Pro Google Font in your project. This is everything you need to get started building UI at Pivotal.
 
-
-[Visit the live styleguide](http://styleguide.pivotal.io)  
-If you are ready to start using Pivotal UI **[download the latest release](https://github.com/pivotal-cf/pivotal-ui/releases)**.   
 To contribute, see the [contributing readme](CONTRIBUTING.md).
 
-***
+## Check it out!
 
-# What's included
-
-- jQuery v2.1.1
-- LoDash v2.4.1
-- Bootstrap v3.2
-- Prism.js
-- Font Awesome v4.10
-- Normalize CSS v1.0.2
-- OOCSS
-- Source Sans Pro
+[Visit the live styleguide](http://styleguide.pivotal.io)  
 
 ***
 
@@ -340,14 +328,6 @@ Import the file and use the variables:
   background-color: $brand-1;
 }
 ```
-
-# Styleguide
-
-Visit <http://styleguide.pivotal.io> of host the styleguide files with a web server to view the available components.
-
-    $ cd /path/to/release/pivotal-ui/styleguide/ && python -m SimpleHTTPServer 8000
-
-then visit <http://localhost:8000>
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Pivotal UI includes Pivotal styles as well as Bootstrap CSS, OOCSS, FontAwesome 
 
 To contribute, see the [contributing readme](CONTRIBUTING.md).
 
-## Check it out!
+# Check it out!
 
 [Visit the live styleguide](http://styleguide.pivotal.io)  
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,86 @@ To contribute, see the [contributing readme](CONTRIBUTING.md).
 
 ***
 
-# Using PivotalUI on your project
+# Using PivotalUI on your project (without React)
+
+The prefered way to consume Pivotal UI is through NPM, even for Rails
+projects. Using NPM to install PUI will ensure proper dependency management on
+your project.
+
+1. Install the Pivotal UI CSS modules
+
+   ```
+   npm install --save pui-css-all
+   ```
+
+1. Install jQuery and bootstrap.js
+
+   ```
+   npm install --save-dev jquery
+   npm install --save-dev bootstrap
+   ```
+
+   These installs must happen **after** you've installed the PUI module. This
+   ensures you'll get the correct version of bootstrap js.
+
+   **NB** - It's important that you install these modules with `--save-dev`.
+   Otherwise Dr. Frankenstyle will try to include CSS from these modules, and
+   your page will look less awesome.
+
+1. Install and run Dr. Frankenstyle
+
+   [Dr. Frankenstyle](http://github.com/pivotal-cf/dr-frankenstyle)
+   is the tool that we recommend using to compile all the PUI css packages
+   together. The simplist way to set it up is:
+
+   ```
+   npm install --save-dev dr-frankenstyle
+   dr-frankenstyle <path-to-your-asset-build-folder>
+   ```
+
+1. Add the css and javascript files to your html template
+
+   ```html
+   <!doctype html>
+   <html>
+     <head>
+       <title>...</title>
+       <link rel="stylesheet" href="<path-to-your-asset-build-folder>/components.css">
+       <script src="<path-to-your-project's-node-modules>/bootstrap/dist/js/bootstrap.js"></script>
+       <script src="<path-to-your-project's-node-modules>/jquery/dist/jquery.js"></script>
+     </head>
+     <body>
+       <!-- ... -->
+     </body>
+   </html>
+   ```
+
+1. Write some CSS/HTML and enjoy!
+
+   ```html
+   <!-- ... -->
+   <body>
+     <div class="container">
+       <h1 class="type-brand-1 em-high">Hello world!</h1>
+     </div>
+   </body>
+   <!-- ... -->
+   ```
+
+1. Upgrade PUI frequently
+
+   ```
+   npm update pui-css-all
+   dr-frankenstyle <path-to-your-asset-build-folder>
+   ```
+
+   **NB** - You must rerun Dr. Frankenstyle after you update PUI (or add any
+   additional CSS module).
+
+# Legacy - Using PivotalUI on your project
+
+If you really don't want to use NPM, you can use our compiled PUI monolith.
+Be warned, you will have to manage updates and dependencies yourself.
 
 1. [Download the latest release](https://github.com/pivotal-cf/pivotal-ui/releases).
 1. Unzip the release archive and move the resulting directory into your project.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ To contribute, see the [contributing readme](CONTRIBUTING.md).
 
 If you're ready to try PUI with React, follow these instructions!
 
+***
+
 **NB** - We're assuming that you have the following setup on your project:
 
   - **Browserify or Webpack** - Our React modules follow the CommonJS module
@@ -43,7 +45,16 @@ If you're ready to try PUI with React, follow these instructions!
   - If these instructions don't make sense to you, don't worry! We're working
     on a sample project template that we'll publish soon :grin:
 
-***
+1. Make sure you have a package.json file. If you don't, run `npm init`, and
+   select the default options.
+
+1. Install [Dr. Frankenstyle](http://github.com/pivotal-cf/dr-frankenstyle).
+   This tool looks at your dependencies (those added with --save, **NOT** 
+   --save-dev), and compiles the CSS required by these packages.
+   
+   ```
+   npm install --save-dev dr-frankenstyle
+   ```
 
 1. Install React, if you haven't already
 
@@ -51,28 +62,21 @@ If you're ready to try PUI with React, follow these instructions!
    npm install --save-dev react
    ```
 
-1. Install a PUI module for the components you need.
+1. Install a PUI module for the components you need. No need to install
+   additional CSS packages. Our React packages tell Dr. Frankenstyle what
+   CSS is needed for each component.
 
    ```
    npm install --save pui-react-typography
+   npm install --save pui-react-buttons
    ```
 
-   Our React component modules include all necessary CSS. So no need to install
-   additional CSS packages!
-
-1. Install and run Dr. Frankenstyle.
-
-   [Dr. Frankenstyle](http://github.com/pivotal-cf/dr-frankenstyle)
-   is a tool that compiles all the CSS required by your React components into
-   a single file. The simplist way to set it up is:
+1. Run Dr. Frankenstyle to compile your CSS
 
    ```
-   npm install --save-dev dr-frankenstyle
    dr-frankenstyle <path-to-your-asset-build-folder>
+   # writes to <path-to-your-asset-build-folder>/components.css
    ```
-
-   The compiled CSS file (and all related fonts/images/etc.) are written to
-   the specified folder.
 
 1. Add the compiled css to your html template
 
@@ -94,12 +98,17 @@ If you're ready to try PUI with React, follow these instructions!
 
 1. Write some React!
 
+   Javascript:
    ```jsx
    var React = require('react');
    var DefaultH1 = require('pui-react-typography').DefaultH1;
    var PrimaryButton = require('pui-react-buttons').PrimaryButton;
 
    var MyTestPage = React.createClass({
+     getInitialState: function() {
+       return {showMessage: false};
+     },
+     
      showMessage: function() {
        this.setState({showMessage: true});
      },
@@ -114,9 +123,10 @@ If you're ready to try PUI with React, follow these instructions!
      }
    });
 
-   React.render(<MyTestPage />, document.findElementById('root'));
+   React.render(<MyTestPage />, document.getElementById('root'));
    ```
 
+   HTML
    ```html
    <!-- ... -->
    <body>
@@ -146,6 +156,17 @@ The prefered way to consume Pivotal UI is through NPM, even for Rails
 projects. Using NPM to install PUI will ensure proper dependency management on
 your project.
 
+1. Make sure you have a package.json file. If you don't, run `npm init`, and
+   select the default options.
+
+1. Install [Dr. Frankenstyle](http://github.com/pivotal-cf/dr-frankenstyle).
+   This tool looks at your dependencies (those added with --save, **NOT** 
+   --save-dev), and compiles the CSS required by these packages.
+   
+   ```
+   npm install --save-dev dr-frankenstyle
+   ```
+
 1. Install the Pivotal UI CSS modules
 
    ```
@@ -165,23 +186,16 @@ your project.
    These installs must happen **after** you've installed the PUI module. This
    ensures you'll get the correct version of bootstrap js.
 
-   **NB** - It's important that you install these modules with `--save-dev`.
-   Otherwise Dr. Frankenstyle will try to include CSS from these modules, and
-   your page will look less awesome.
+   **NB** - It's important that you install these modules with `--save-dev`,
+   because we don't want Dr. Frankenstyle to pick up any CSS from these
+   packages.
 
-1. Install and run Dr. Frankenstyle
-
-   [Dr. Frankenstyle](http://github.com/pivotal-cf/dr-frankenstyle)
-   is the tool that we recommend using to compile all the PUI css packages
-   together. The simplist way to set it up is:
+1. Run Dr. Frankenstyle to compile your CSS
 
    ```
-   npm install --save-dev dr-frankenstyle
    dr-frankenstyle <path-to-your-asset-build-folder>
+   # writes to <path-to-your-asset-build-folder>/components.css
    ```
-
-   The compiled CSS file (and all related fonts/images/etc.) are written to
-   the specified folder.
 
 1. Add the css and javascript files to your html template
 
@@ -191,8 +205,8 @@ your project.
      <head>
        <title>...</title>
        <link rel="stylesheet" href="<path-to-your-asset-build-folder>/components.css">
-       <script src="<path-to-your-project's-node-modules>/bootstrap/dist/js/bootstrap.js"></script>
-       <script src="<path-to-your-project's-node-modules>/jquery/dist/jquery.js"></script>
+       <script src="<path-to-your-project's-root-folder>/node-modules/jquery/dist/jquery.js"></script>
+       <script src="<path-to-your-project's-root-folder>/node-modules/bootstrap/dist/js/bootstrap.js"></script>
      </head>
      <body>
        <!-- ... -->

--- a/README.md
+++ b/README.md
@@ -46,21 +46,27 @@ To contribute, see the [contributing readme](CONTRIBUTING.md).
 </html>
 ```
 
-You'll need to maintain the structure in the release directory to have fonts and assets work properly. **Do not modify the release files directly**. If you need a component and you cannot find it in the styleguide, write your own styles and javascript separately. Doing so will make it easier to update to newer versions.
-
+You'll need to maintain the structure in the release directory to have fonts
+and assets work properly. **Do not modify the release files directly**. If you
+need a component and you cannot find it in the styleguide, write your own
+styles and javascript separately. Doing so will make it easier to update to
+newer versions.
 
 # Using PivotalUI on your Rails project
 
-If you're installing PivotalUI into a Rails project, you should unzip the constituent files into a directory named `vendor/assets/pui-vX.X.X`.
+If you're installing PivotalUI into a Rails project, you should unzip the
+constituent files into a directory named `vendor/assets/pui-vX.X.X`.
 
 In your `application.scss` file, add the line `@import "pivotal-ui-rails"`
 
-In your `application.js` file, add the line `//= require pivotal-ui` as **the very first** require declaration.
+In your `application.js` file, add the line `//= require pivotal-ui` as **the
+very first** require declaration.
 
-Lastly, in your application's `config/application.rb`, you'll need to add the following to make sure all vendored files are properly compiled:
+Lastly, in your application's `config/application.rb`, you'll need to add the
+following to make sure all vendored files are properly compiled:
 
 ```
-    config.assets.precompile << /\.(?:svg|eot|woff|ttf)\z/
+  config.assets.precompile << /\.(?:svg|eot|woff|ttf)\z/
 ```
 
 # Including SCSS variables and mixins (optional, beta)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ your project.
    dr-frankenstyle <path-to-your-asset-build-folder>
    ```
 
+   The compiled CSS file (and all related fonts/images/etc.) are written to
+   the specified folder.
+
 1. Add the css and javascript files to your html template
 
    ```html

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ If you're ready to try PUI with React, follow these instructions!
   - If these instructions don't make sense to you, don't worry! We're working
     on a sample project template that we'll publish soon :grin:
 
-1. Make sure you have a package.json file. If you don't, run `npm init`, and
-   select the default options.
+1. Run `npm init` if you don't have a package.json file already.
 
 1. Install [Dr. Frankenstyle](http://github.com/pivotal-cf/dr-frankenstyle).
    This tool looks at your dependencies (those added with --save, **NOT** 
@@ -140,8 +139,7 @@ The prefered way to consume Pivotal UI is through NPM, even for Rails
 projects. Using NPM to install PUI will ensure proper dependency management on
 your project.
 
-1. Make sure you have a package.json file. If you don't, run `npm init`, and
-   select the default options.
+1. Run `npm init` if you don't have a package.json file already.
 
 1. Install [Dr. Frankenstyle](http://github.com/pivotal-cf/dr-frankenstyle).
    This tool looks at your dependencies (those added with --save, **NOT** 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,122 @@ To contribute, see the [contributing readme](CONTRIBUTING.md).
 
 ***
 
-# Using PivotalUI on your project (without React)
+# Using Pivotal UI on your project (with React)
+
+If you're ready to try PUI with React, follow these instructions!
+
+**NB** - We're assuming that you have the following setup on your project:
+
+  - **Browserify or Webpack** - Our React modules follow the CommonJS module
+    pattern. You will need to use [Browserify](http://browserify.org/) or
+    [Webpack](http://webpack.github.io/) to compile your javascript for use
+    in the browser.
+
+  - **A JSX transpiler** - It's easiest to write React code with [JSX](https://facebook.github.io/react/docs/jsx-in-depth.html).
+    You will need a transpiler to convert your JSX code into plain javascript
+    for use in the browser. We recommend [Babel](https://babeljs.io/).
+
+  - If these instructions don't make sense to you, don't worry! We're working
+    on a sample project template that we'll publish soon :grin:
+
+***
+
+1. Install React, if you haven't already
+
+   ```
+   npm install --save-dev react
+   ```
+
+1. Install a PUI module for the components you need.
+
+   ```
+   npm install --save pui-react-typography
+   ```
+
+   Our React component modules include all necessary CSS. So no need to install
+   additional CSS packages!
+
+1. Install and run Dr. Frankenstyle.
+
+   [Dr. Frankenstyle](http://github.com/pivotal-cf/dr-frankenstyle)
+   is a tool that compiles all the CSS required by your React components into
+   a single file. The simplist way to set it up is:
+
+   ```
+   npm install --save-dev dr-frankenstyle
+   dr-frankenstyle <path-to-your-asset-build-folder>
+   ```
+
+   The compiled CSS file (and all related fonts/images/etc.) are written to
+   the specified folder.
+
+1. Add the compiled css to your html template
+
+   ```html
+   <!doctype html>
+   <html>
+     <head>
+       <title>...</title>
+       <script src="<path-to-your-project's-compiled-javascript-file>"></script>
+
+       <link rel="stylesheet" href="<path-to-your-asset-build-folder>/components.css">
+
+     </head>
+     <body>
+       <!-- ... -->
+     </body>
+   </html>
+   ```
+
+1. Write some React!
+
+   ```jsx
+   var React = require('react');
+   var DefaultH1 = require('pui-react-typography').DefaultH1;
+   var PrimaryButton = require('pui-react-buttons').PrimaryButton;
+
+   var MyTestPage = React.createClass({
+     showMessage: function() {
+       this.setState({showMessage: true});
+     },
+
+     render: function() {
+       return (
+         <div className="container">
+	   <PrimaryButton onClick={this.showMessage}>Show Message</PrimaryButton>
+	   { this.state.showMessage ? <DefaultH1>Hello world!</DefaultH1> : null }
+	 </div>
+       );
+     }
+   });
+
+   React.render(<MyTestPage />, document.findElementById('root'));
+   ```
+
+   ```html
+   <!-- ... -->
+   <body>
+     <div id="root"></div>
+   </body>
+   <!-- ... -->
+   ```
+
+1. Every time you install a new PUI React package, you will need to rerun
+   Dr. Frankenstyle to update your compiled CSS.
+
+   ```
+   npm install --save pui-react-alerts
+   dr-frankenstyle <path-to-your-asset-build-folder>
+   ```
+
+   If you're using gulp or grunt or some other task runner,
+   look at the [Dr. Frankenstyle docs](http://github.com/pivotal-cf/dr-frankenstyle)
+   for how to make this step part of your task workflow.
+
+# Using Pivotal UI on your project (without React)
+
+If you're not ready to try React, you can still use the HTML/CSS version of
+Pivotal UI!
 
 The prefered way to consume Pivotal UI is through NPM, even for Rails
 projects. Using NPM to install PUI will ensure proper dependency management on
@@ -219,27 +334,6 @@ Visit <http://styleguide.pivotal.io> of host the styleguide files with a web ser
     $ cd /path/to/release/pivotal-ui/styleguide/ && python -m SimpleHTTPServer 8000
 
 then visit <http://localhost:8000>
-
-# React components
-
-If you'd like to try out react, swap in the react js file in place of the
-standard file: 
-
-```html
-
-<script src="/path/to/release/pivotal-ui.js"></script> 
-
-```
-
-Should become:
-
-```html
-
-<script src="/path/to/release/pivotal-ui-react.js"></script>
-
-```
-
-***
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ your project.
    npm install --save pui-css-all
    ```
 
+   If you only want to include a few PUI components in your project, see the
+   instructions below on [customizing your PUI build](#customizing-your-pui-build).
+
 1. Install jQuery and bootstrap.js
 
    ```
@@ -100,6 +103,43 @@ your project.
 
    **NB** - You must rerun Dr. Frankenstyle after you update PUI (or add any
    additional CSS module).
+
+## Customizing your PUI build
+
+If you don't want all of Pivotal UI, you can install only the modules you will
+need. This will make your resultant CSS smaller! Let's say you're building an
+app that only has typography and buttons.
+
+1. Remove the `pui-css-all` module from your project.
+
+   ```
+   npm uninstall --save pui-css-all
+   ```
+
+1. Add the necessary PUI CSS modules. For this example
+
+   ```
+   npm install --save pui-css-typography
+   npm install --save pui-css-buttons
+   ```
+
+   Use the styleguide to determine which modules you need to install. Each
+   component contains module information at the beginning of its docs:
+
+   ![Example of styleguide installation instructions](https://cloud.githubusercontent.com/assets/824157/8711815/22853a7a-2b0a-11e5-862a-a76488de81e8.png)
+
+1. Rerun Dr. Frankenstyle
+
+   ```
+   dr-frankenstyle <path-to-your-asset-build-folder>
+   ```
+
+1. Every time you install a new PUI CSS package, you will need to rerun
+   Dr. Frankenstyle.
+
+   If you're using gulp or grunt or some other task runner,
+   look at the [Dr. Frankenstyle docs](http://github.com/pivotal-cf/dr-frankenstyle)
+   for how to make this step part of your task workflow.
 
 # Legacy - Using PivotalUI on your project
 

--- a/README.md
+++ b/README.md
@@ -215,32 +215,6 @@ Visit <http://styleguide.pivotal.io> of host the styleguide files with a web ser
 
 then visit <http://localhost:8000>
 
-# Syntax Highlighting
-
-There are two themes, **dark** and **light**, for syntax highlighting. You can choose a theme by linking to one of the following stylesheets:
-
-* `pivotal-ui/prismjs/prism.css` (for the light theme)
-* `pivotal-ui/prismjs/prism-okaidia.css` (for the dark theme).
-
-You can only include one of these themes at a time.
-
-See the latest styleguide for [examples of syntax highlighting in action](http://styleguide.pivotal.io/all.html#code).
-
-## Syntax Highlighting Example
-
-```html
-
-  <pre>
-	<code class='language-ruby'>
-	  class Foo
-	    def bar
-	    end
-	  end
-	</code>
-  </pre>
-
-```
-
 # React components
 
 If you'd like to try out react, swap in the react js file in place of the

--- a/README.md
+++ b/README.md
@@ -190,17 +190,19 @@ following to make sure all vendored files are properly compiled:
 
 # Including SCSS variables and mixins (optional, beta)
 
-If you are building CSS using Sass, you can get pivotal-ui variables and mixins from the [pui-css-variables-and-mixins](https://www.npmjs.com/package/pui-css-variables-and-mixins) node module.
+If you are building CSS using Sass, you can get pivotal-ui variables and mixins
+from the [pui-css-variables-and-mixins](https://www.npmjs.com/package/pui-css-variables-and-mixins)
+node module.
 
-```sh
-  $ npm install --save pui-css-variables-and-mixins
+```
+npm install --save pui-css-variables-and-mixins
 ```
 
 Import the file and use the variables:
 
 ```scss
-@import '/path/to/pui-variables.scss';
-@import '/path/to/mixins.scss';
+@import '<path-to-your-projects-node-modules>/pui-css-variables-and-mixins/pui-variables.scss';
+@import '<path-to-your-projects-node-modules>/pui-css-variables-and-mixins/mixins.scss';
 
 .bg-special {
   background-color: $brand-1;


### PR DESCRIPTION
This is a WIP PR. Don't merge yet! I'm continually adding changes.

Updates
- Add basic HTML/CSS npm-based install instructions (using `pui-css-all`, `dr-frankenstyle`)
  - Section: "Using PivotalUI on your project (without React)"

- Add instructions for creating a custom HTML/CSS build w/ npm (installing individual `pui-css-*` packages).
  - Section: "Customizing your PUI build"

- Add React npm-based install instructions
  - Section: "Using PivotalUI on your project (with React)"

- Removed "Syntax Highlighting" section
  - Those docs have been moved into the "Code" component docs in the styleguide

- Fixed instructions for "Mixins and Variables"