### PR TITLE
fix(collapse): Adds test for className and style passthrough

### DIFF
--- a/spec/pivotal-ui-react/collapse/collapse_spec.js
+++ b/spec/pivotal-ui-react/collapse/collapse_spec.js
@@ -60,25 +60,43 @@ describe('BaseCollapse', function() {
 });
 
 describe('Collapse', function() {
-  var Collapse, subject;
+  var Collapse, props;
   beforeEach(function() {
     Collapse = require('../../../src/pivotal-ui-react/collapse/collapse').Collapse;
 
-    subject = TestUtils.renderIntoDocument(
-      <Collapse header="ima header">
+    props = {
+      className: 'test-class',
+      style: {
+        opacity: '1'
+      }
+    };
+
+    React.render(
+      <Collapse header="ima header" {...props}>
         <h1>Child</h1>
-      </Collapse>
-    );
+      </Collapse>,
+      root);
+  });
+
+  afterEach(function() {
+    React.unmountComponentAtNode(root);
+  });
+
+  it('passes through className', function() {
+    expect('#root .panel').toHaveClass('test-class');
+  });
+
+  it('passes through style', function() {
+    expect('#root .panel').toHaveCss({opacity: '1'});
   });
 
   it('contains a right-caret as its collapsed icon', function() {
-    var collapsedIconContainer = TestUtils.findRenderedDOMComponentWithClass(subject, 'when-collapsed-inline');
-    expect(TestUtils.findRenderedDOMComponentWithClass(collapsedIconContainer, 'fa-caret-right')).toBeTruthy();
+    expect('#root when-collapsed-inline fa-caret-right').toBeTruthy();
   });
 
+
   it('contains a down-caret as its collapsed icon', function() {
-    var expandedIconContainer = TestUtils.findRenderedDOMComponentWithClass(subject, 'when-expanded-inline');
-    expect(TestUtils.findRenderedDOMComponentWithClass(expandedIconContainer, 'fa-caret-down')).toBeTruthy();
+    expect('#root when-expanded-inline fa-caret-down').toBeTruthy();
   });
 });
 

--- a/src/pivotal-ui-react/collapse/collapse.js
+++ b/src/pivotal-ui-react/collapse/collapse.js
@@ -1,7 +1,7 @@
 var React = require('react');
 var types = React.PropTypes;
 var BsPanel = require('react-bootstrap').Panel;
-var classnames = require('classnames');
+import {mergeProps} from '../../../src/pivotal-ui-react/helpers/helpers';
 
 var CollapseProps = {
   propTypes: {
@@ -47,10 +47,10 @@ var BaseCollapse = React.createClass({
 
   render() {
     var {divider, header, children, ...others} = this.props;
-    var classes = classnames({'panel-divider': divider});
+    var props = mergeProps(others, {className: {'panel-divider': divider}});
 
     return (
-      <BsPanel {...others} className={classes} collapsible expanded={this.state.expanded} onSelect={this.handleSelect} header={header}>
+      <BsPanel {...props} collapsible expanded={this.state.expanded} onSelect={this.handleSelect} header={header}>
         {children}
       </BsPanel>
     );


### PR DESCRIPTION
Tests that className and style are passed through to the div containing
the collapse. react-bootstrap passes id to the content of the collapse.
Refactors BaseCollapse to use mergeprops.

[Finishes #98913410]