### PR TITLE
feat(stream-list): Creates a stream-list component

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "pui-css-whitespace": "1.10.0",
     "pui-prismjs": "0.0.1",
     "pui-react-alerts": "1.10.0",
+    "pui-react-animation": "0.0.7",
     "pui-react-back-to-top": "1.10.0",
     "pui-react-buttons": "1.10.0",
     "pui-react-collapse": "1.10.0",

--- a/spec/pivotal-ui-react/stream-list/stream-list_spec.js
+++ b/spec/pivotal-ui-react/stream-list/stream-list_spec.js
@@ -1,0 +1,121 @@
+require('../spec_helper');
+
+import {ListItem} from '../../../src/pivotal-ui-react/lists/lists';
+import {StreamList} from '../../../src/pivotal-ui-react/stream-list/stream-list';
+import {itPropagatesAttributes} from '../support/shared_examples';
+import EventEmitter from 'node-event-emitter';
+
+describe('StreamList', () => {
+  afterEach(() => {
+    React.unmountComponentAtNode(root);
+  });
+
+  describe('initial render', () => {
+    const props = {
+      className: 'my-stream-list-class',
+      id: 'my-stream-list-id',
+      style: {
+        opacity: '0.5'
+      }
+    };
+
+    beforeEach(() => {
+      const streamList = (
+        <StreamList {...props} singularNewItemText="new thing" pluralNewItemsText="new things">
+          <ListItem>Item a</ListItem>
+          <ListItem>Item b</ListItem>
+          <ListItem>Item c</ListItem>
+        </StreamList>
+      );
+      React.render(streamList, root);
+    });
+
+
+    it('renders a group list', () => {
+      expect('#root .list-group').toExist();
+      expect('#root .list-group li.list-group-item').toHaveLength(3);
+    });
+
+    itPropagatesAttributes('#root .list-group', props);
+
+    it('displays the list items in reverse order', () => {
+      expect('#root .list-group li:eq(0)').toHaveText('Item c');
+      expect('#root .list-group li:eq(1)').toHaveText('Item b');
+      expect('#root .list-group li:eq(2)').toHaveText('Item a');
+    });
+  });
+
+  describe('when a new item is added to the list', () => {
+    let streamListExample, addData;
+
+    beforeEach(() => {
+      addData = new EventEmitter();
+
+      const StreamListExample = React.createClass({
+        componentDidMount() {
+          addData.on('data', datum => {
+            const newData = this.state.data.concat([datum]);
+            this.setState({data: newData});
+          });
+        },
+
+        getInitialState() {
+          return {data: ['Item a', 'Item b', 'Item c']};
+        },
+
+        render() {
+          return (<StreamList singularNewItemText="new thing" pluralNewItemsText="new things">
+            {this.state.data.map((datum, i) => <ListItem key={i}>{datum}</ListItem>)}
+          </StreamList>);
+        }
+      });
+
+      streamListExample = <StreamListExample/>;
+      React.render(streamListExample, root);
+    });
+
+    it('adds a New Items button to the top of the list, using the appropriate singular/plural text', () => {
+      addData.emit('data', 'Item d');
+      expect('#root .list-stream-new-items-btn').toHaveText('1 new thing');
+      addData.emit('data', 'Item e');
+      expect('#root .list-stream-new-items-btn').toHaveText('2 new things');
+      addData.emit('data', 'Item f');
+      addData.emit('data', 'Item g');
+      expect('#root .list-stream-new-items-btn').toHaveText('4 new things');
+    });
+
+    it('does not add any lis', () => {
+      addData.emit('data', 'Item d');
+      expect('#root .list-group li.list-group-item').toHaveLength(3);
+      expect('#root .list-group li:eq(0)').toHaveText('Item c');
+      expect('#root .list-group li:eq(1)').toHaveText('Item b');
+      expect('#root .list-group li:eq(2)').toHaveText('Item a');
+    });
+
+    describe('clicking the New Items button', () => {
+      it('displays the new elements', () => {
+        addData.emit('data', 'Item d');
+        expect('#root .list-stream-new-items-btn').toHaveText('1 new thing');
+        $('#root .list-stream-new-items-btn').simulate('click');
+        expect('#root .list-group li:eq(0)').toHaveText('Item d');
+        expect('#root .list-group li:eq(1)').toHaveText('Item c');
+        expect('#root .list-group li:eq(2)').toHaveText('Item b');
+        expect('#root .list-group li:eq(3)').toHaveText('Item a');
+        expect('#root .list-stream-new-items-btn').not.toExist();
+
+        addData.emit('data', 'Item e');
+        addData.emit('data', 'Item f');
+        expect('#root .list-stream-new-items-btn').toHaveText('2 new things');
+        $('#root .list-stream-new-items-btn').simulate('click');
+        expect('#root .list-group li:eq(0)').toHaveText('Item f');
+        expect('#root .list-group li:eq(1)').toHaveText('Item e');
+        expect('#root .list-group li:eq(2)').toHaveText('Item d');
+        expect('#root .list-group li:eq(3)').toHaveText('Item c');
+        expect('#root .list-group li:eq(4)').toHaveText('Item b');
+        expect('#root .list-group li:eq(5)').toHaveText('Item a');
+        expect('#root .list-stream-new-items-btn').not.toExist();
+
+      });
+    });
+  });
+});

--- a/spec/task-helpers/package-version-helper-spec.js
+++ b/spec/task-helpers/package-version-helper-spec.js
@@ -226,11 +226,15 @@ describe('componentsToUpdate', function() {
         dependencies: ['pui-css-lists']
       }));
       expect(result).toContain(jasmine.objectContaining({
+        component: 'src/pivotal-ui-react/stream-list/',
+        dependencies: ['pui-react-lists']
+      }));
+      expect(result).toContain(jasmine.objectContaining({
         component: 'src/pivotal-ui-react/notifications/',
         dependencies: ['pui-react-dropdowns', 'pui-react-iconography']
       }));
       expect(result).toContain(jasmine.objectContaining({ component: './' }));
-      expect(result.length).toEqual(22);
+      expect(result.length).toEqual(23);
     });
   });
 });

--- a/src/pivotal-ui-react/stream-list/package.json
+++ b/src/pivotal-ui-react/stream-list/package.json
@@ -1,0 +1,10 @@
+{
+  "version": "0.1.0",
+  "description": "A React component for showing a dynamically growing list of items",
+  "homepage": "http://styleguide.pivotal.io/react.html#12_list_stream_react",
+  "dependencies": {
+    "pui-react-buttons": "^0.0.5",
+    "pui-react-lists": "^0.0.5",
+    "pui-react-animation": "0.0.7"
+  }
+}

--- a/src/pivotal-ui-react/stream-list/stream-list.js
+++ b/src/pivotal-ui-react/stream-list/stream-list.js
@@ -1,0 +1,137 @@
+import React from 'react/addons';
+import {UIButton} from 'pui-react-buttons';
+import {GroupList} from 'pui-react-lists';
+import AnimationMixin from 'pui-react-animation';
+
+/**
+ * @component StreamList
+ * @description A dynamically growing list
+ *
+ * @property singularNewItemText {string} Text to be displayed when there is one new list item available
+ * @property pluralNewItemsText {string} Text to be displayed when there are multiple new list items available
+ *
+ * @example ```jsx
+ *  var DefaultButton = require('pui-react-buttons').DefaultButton;
+ *  var ListItem = require('pui-react-lists').ListItem;
+ *  var StreamList = require('pui-react-stream-list').StreamList;
+ *
+ *  var counter = (function() {
+ *  var i = 4;
+ *    return function() {
+ *      return i++;
+ *    }
+ *  })();
+ *
+ *  var StreamListExample = React.createClass({
+ *    simulateIncomingData: function() {
+ *      var newData = this.state.data.concat(['Event ' + counter()]);
+ *      this.setState({data: newData});
+ *    },
+ *
+ *    getInitialState: function() {
+ *      return {data: ['Event 1', 'Event 2', 'Event 3']};
+ *    },
+ *
+ *    render: function() {
+ *      return (
+ *        <div>
+ *          <DefaultButton onClick={this.simulateIncomingData}>Simulate Incoming Data</DefaultButton>
+ *          <StreamList singularNewItemText="new thing" pluralNewItemsText="new things">
+ *            {this.state.data.map(function(datum) {
+ *              return <ListItem>{datum}</ListItem>
+ *            })}
+ *          </StreamList>
+ *         </div>
+ *      );
+ *    }
+ *  });
+ * ```
+ *
+ * @see [Pivotal UI React](http://styleguide.pivotal.io/react.html#list_draggable_react)
+ */
+
+/**
+ * @component DraggableListItem
+ * @description Denotes list items of a DraggableList
+ *
+ * @see [Pivotal UI React](http://styleguide.pivotal.io/react.html#list_draggable_react)
+ */
+
+const StreamListNewItemsButton = React.createClass({
+  propTypes: {
+    showNewItems: React.PropTypes.func.isRequired,
+    singularNewItemText: React.PropTypes.string,
+    pluralNewItemsText: React.PropTypes.string,
+    numNewItems: React.PropTypes.number.isRequired
+  },
+
+  render() {
+    return (
+      <UIButton className="list-stream-new-items-btn"
+                onClick={this.props.showNewItems}>
+        {`${this.props.numNewItems} ${this.props.numNewItems === 1 ?
+          this.props.singularNewItemText : this.props.pluralNewItemsText}`}
+      </UIButton>
+    );
+  }
+});
+
+export const StreamList = React.createClass({
+  mixins: [AnimationMixin],
+
+  propTypes: {
+    singularNewItemText: React.PropTypes.string.isRequired,
+    pluralNewItemsText: React.PropTypes.string.isRequired
+  },
+
+  getDefaultProps() {
+    return {
+      singularNewItemText: 'new item',
+      pluralNewItemsText: 'new items'
+    };
+  },
+
+  getInitialState() {
+    return {numRenderedItems: this.numTotalItems()};
+  },
+
+  numTotalItems() {
+    return React.Children.count(this.props.children);
+  },
+
+  numNewItems() {
+    return this.numTotalItems() - this.state.numRenderedItems;
+  },
+
+  showNewItems() {
+    this.setState({numRenderedItems: this.numTotalItems()});
+  },
+
+  render() {
+    const {children, singularNewItemText, pluralNewItemsText, ...others} = this.props;
+    const updatedChildren = [];
+    React.Children.forEach(children, child => {
+      if (updatedChildren.length === this.state.numRenderedItems) return;
+      updatedChildren.unshift(child);
+    });
+    let newItemsButton = null;
+    let height = 0;
+    if (this.numNewItems()) {
+      const newItemsBtnProps = {
+        showNewItems: this.showNewItems,
+        singularNewItemText,
+        pluralNewItemsText,
+        numNewItems: this.numNewItems()
+      };
+      newItemsButton = <StreamListNewItemsButton {...newItemsBtnProps} />;
+      height = this.animate(`list-stream-btn-key-${this.state.numRenderedItems}`, 45, 150, {startValue: 0});
+      // animating using `numRenderedItems` makes a new animation every time the button appears
+    }
+    return (
+      <div>
+        <div className="list-stream-new-items-btn-wrapper" style={{height}}>{newItemsButton}</div>
+        <GroupList {...others}>{updatedChildren}</GroupList>
+      </div>
+    );
+  }
+});

--- a/src/pivotal-ui/components/lists/lists.scss
+++ b/src/pivotal-ui/components/lists/lists.scss
@@ -1100,24 +1100,112 @@ parent: list_react
 
 /*doc
 ---
-title: Unordered
-name: 12_list_unordered_react
+title: Stream List
+name: 12_list_stream_react
 parent: list_react
 ---
 
-```react_example_table
-<UI.UnorderedList>
-  <UI.ListItem>feep</UI.ListItem>
-  <UI.ListItem>fop</UI.ListItem>
-  <UI.ListItem>meep</UI.ListItem>
-</UI.UnorderedList>
+<code class="pam">
+<i class="fa fa-download" alt="Install the Component">
+npm install pui-react-stream-list --save
+npm install pui-react-lists --save
+</i>
+</code>
+
+Require the subcomponent:
+
+```js
+var StreamList = require('pui-react-stream-list').StreamList;
+var ListItem = require('pui-react-stream-list').ListItem;
 ```
+
+Use this component when you have streaming/polling data that you want to
+display in a list. As items roll in (polling, streams, websockets - your choice), add the
+items to the list. The user will see a "n new item(s)" button animate in
+at the top of the list. When the user clicks the button, the new items
+appear in the list.
+
+
+```jsx_example
+var counter = (function() {
+  var i = 4;
+  return function() {
+    return i++;
+  }
+})();
+
+var StreamListExample = React.createClass({
+  simulateIncomingData: function() {
+    var newData = this.state.data.concat(['Event ' + counter()]);
+    this.setState({data: newData});
+  },
+
+  getInitialState: function() {
+    return {data: ['Event 1', 'Event 2', 'Event 3']};
+  },
+
+  render: function() {
+    return (
+      <div>
+        <UI.DefaultButton onClick={this.simulateIncomingData}>Simulate Incoming Data</UI.DefaultButton>
+        <UI.StreamList singularNewItemText="new thing" pluralNewItemsText="new things">
+          {this.state.data.map(function(datum, i) {
+            return <UI.ListItem key={i}>{datum}</UI.ListItem>
+          })}
+        </UI.StreamList>
+       </div>
+    );
+  }
+});
+```
+
+```react_example
+<StreamListExample />
+```
+
 */
+
+.list-stream-new-items-btn-wrapper {
+  overflow: hidden;
+}
+
+.list-stream-new-items-btn {
+  font-weight: $font-weight-em-high;
+  background-color: $neutral-10;
+  color: $navy-3;
+  width: 100%;
+  height: 45px;
+  padding: 0;
+  border-radius: 0;
+  border-top: 1px solid $list-group-border;
+  box-shadow: 0px -1px $shadow-4;
+
+  &:hover {
+    background-color: darken($neutral-10, 20%);
+    color: $navy-3;
+  }
+}
+
+  /*doc
+  ---
+  title: Unordered
+  name: 13_list_unordered_react
+  parent: list_react
+  ---
+
+  ```react_example_table
+  <UI.UnorderedList>
+    <UI.ListItem>feep</UI.ListItem>
+    <UI.ListItem>fop</UI.ListItem>
+    <UI.ListItem>meep</UI.ListItem>
+  </UI.UnorderedList>
+  ```
+  */
 
 /*doc
 ---
 title: Unstyled
-name: 13_list_unstyled_react
+name: 14_list_unstyled_react
 parent: list_react
 ---
 

--- a/src/pivotal-ui/javascripts/components.js
+++ b/src/pivotal-ui/javascripts/components.js
@@ -1,4 +1,6 @@
 var sortableTable = require('pui-react-sortable-table');
+var streamList = require('pui-react-stream-list');
+
 module.exports = {
   DefaultH1: require('pui-react-typography').DefaultH1,
   DefaultH2: require('pui-react-typography').DefaultH2,
@@ -119,4 +121,6 @@ module.exports = {
 
   PortalSource: require('pui-react-portals').PortalSource,
   PortalDestination: require('pui-react-portals').PortalDestination,
-  ...sortableTable};
+  ...sortableTable,
+  ...streamList
+};


### PR DESCRIPTION
Some open questions we had around the API design:

1. Should ListItems appear in reversed order? I.e. does 
```jsx
<StreamList>
  <ListItem>Item a</ListItem>
  <ListItem>Item b</ListItem>
```
render as:
```
Item b
Item a
```
This is so that new data appears on the top of the list.

2. Should the stream list be component be a `StreamList` (i.e. a separate component than `GroupList`)? Or should the stream list be a `GroupList` with `stream={true}` (or a similar property)?

3. The text on the button: we have two props - `singularNewItemText` and `pluralNewItemsText`. So the button would say "1 {singularNewItemText}" or "4 {pluralNewItemsText}" (e.g. "1 new item", "4 new items"). If not supplied, we provide the default values of "new item"/"new items". Does this seem like a necessary/reasonable way of making the text modular? Do you have a better idea for prop names?