### PR TITLE
fix(expander): Handle expander open animation correctly

### DIFF
--- a/spec/features/components/expander_spec.rb
+++ b/spec/features/components/expander_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../spec_helper'
+
+feature 'React Expander', js: true do
+  scenario 'using the component' do
+    visit '/react.html#expander_react'
+
+    within_example_containing('Toggle Content') do
+      expect(page).not_to have_content('Content in expander')
+
+      click_on 'Toggle Content'
+
+      expect(page).to have_content('Content in expander')
+
+      click_on 'Toggle Content'
+
+      expect(page).not_to have_content('Content in expander')
+    end
+  end
+end

--- a/spec/features/spec_helper.rb
+++ b/spec/features/spec_helper.rb
@@ -31,3 +31,11 @@ RSpec.configure do |config|
   config.tty = true
   config.formatter = :documentation
 end
+
+def within_example_containing(text)
+  example = page.find(:xpath, "//div[contains(@class, 'exampleOutput') and contains(., '#{text}')]")
+  within example do
+    yield
+  end
+end
+

--- a/spec/pivotal-ui-react/expander/expander_spec.js
+++ b/spec/pivotal-ui-react/expander/expander_spec.js
@@ -1,12 +1,6 @@
 require('../spec_helper');
 
 describe('ExpanderContent', function() {
-  beforeEach(function() {
-    spyOn(React.addons.CSSTransitionGroup.prototype, 'render').and.callFake(function() {
-      return React.createElement('div', this.props);
-    });
-  });
-
   afterEach(function() {
     React.unmountComponentAtNode(root);
   });
@@ -28,47 +22,49 @@ describe('ExpanderContent', function() {
 
   describe('initial state', function() {
     describe('when expanded is unset', function() {
-      it('does not render the content', function() {
+      it('hides the content', function() {
         renderComponent.call(this, {});
-        expect(root).not.toContainText('You won a brand new car!');
+        expect('.collapse').not.toHaveClass('in');
       });
     });
 
     describe('when expanded is set to false', function() {
-      it('does not render the content', function() {
-        renderComponent.call(this, {expanded: false});
-        expect(root).not.toContainText('You won a brand new car!');
+      it('hides the content', function() {
+        renderComponent.call(this, {});
+        expect('.collapse').not.toHaveClass('in');
       });
     });
 
     describe('when expanded is set to true', function() {
-      it('renders the content', function() {
+      it('shows the content', function() {
         renderComponent.call(this, {expanded: true});
-        expect(root).toContainText('You won a brand new car!');
+        expect('.collapse').toHaveClass('in');
       });
     });
   });
 
   describe('#toggle', function() {
-    describe('when the content is already visible', function() {
+    describe('when the content was already visible', function() {
       beforeEach(function() {
-        this.expanderContent = renderComponent.call(this, {expanded: true});
+        let expanderContent = renderComponent.call(this, {expanded: true});
+        expanderContent.toggle();
+        jasmine.clock().tick(1000);
       });
 
-      it('stops rendering the content', function() {
-        this.expanderContent.toggle();
-        expect(root).not.toContainText('You won a brand new car!');
+      it('hides the content', function() {
+        expect('.collapse').not.toHaveClass('in');
       });
     });
 
     describe('when the content is not visible', function() {
       beforeEach(function() {
         this.expanderContent = renderComponent.call(this, {expanded: false});
+        this.expanderContent.toggle();
+        jasmine.clock().tick(1000);
       });
 
-      it('renders the content', function() {
-        this.expanderContent.toggle();
-        expect(root).toContainText('You won a brand new car!');
+      it('shows the content', function() {
+        expect('.collapse').toHaveClass('in');
       });
     });
 
@@ -76,10 +72,12 @@ describe('ExpanderContent', function() {
       this.expanderContent = renderComponent.call(this);
 
       this.expanderContent.toggle();
-      expect(root).toContainText('You won a brand new car!');
+      jasmine.clock().tick(1000);
+      expect('.collapse').toHaveClass('in');
 
       this.expanderContent.toggle();
-      expect(root).not.toContainText('You won a brand new car!');
+      jasmine.clock().tick(1000);
+      expect('.collapse').not.toHaveClass('in');
     });
   });
 });

--- a/src/pivotal-ui-react/expander/expander.js
+++ b/src/pivotal-ui-react/expander/expander.js
@@ -1,5 +1,5 @@
 var React = require('react/addons');
-var {CSSTransitionGroup} = React.addons;
+var Collapse = require('react-bootstrap/lib/Collapse');
 
 /**
  * @component ExpanderTrigger
@@ -68,10 +68,13 @@ var ExpanderContent = React.createClass({
   },
 
   render() {
-    var content = this.state.expanded ?
-      <div key="expandedContent" style={{overflow: 'hidden'}}>{this.props.children}</div> :
-      null;
-    return <CSSTransitionGroup transitionName="expander">{content}</CSSTransitionGroup>;
+    return (
+      <Collapse in={this.state.expanded}>
+        <div style={{overflow: 'hidden'}}>
+          {this.props.children}
+        </div>
+      </Collapse>
+    );
   }
 });
 

--- a/src/pivotal-ui-react/expander/package.json
+++ b/src/pivotal-ui-react/expander/package.json
@@ -1,5 +1,9 @@
 {
   "version": "1.10.0",
   "description": "A React component that provides an accordion for showing and hiding content where the toggle and the content can be in separate places",
-  "homepage": "http://styleguide.pivotal.io/react.html#expander_react"
+  "homepage": "http://styleguide.pivotal.io/react.html#expander_react",
+  "dependencies": {
+    "react-bootstrap": "pivotal-cf/react-bootstrap#pui-dist",
+    "pui-css-bootstrap": "1.10.0"
+  }
 }

--- a/src/pivotal-ui/components/expander/expander.scss
+++ b/src/pivotal-ui/components/expander/expander.scss
@@ -39,7 +39,7 @@ var MoreInfo = React.createClass({
     return (
       <main>
         <UI.ExpanderContent ref="infoContent">
-          <p className='h1 bg-neutral-2 type-neutral-9'>Hamburgers</p>
+          <p className='h1 bg-neutral-2 type-neutral-9'>Content in expander</p>
         </UI.ExpanderContent>
         <br/>
         <UI.ExpanderTrigger ref="infoTrigger">

--- a/src/pivotal-ui/components/react-animations/react-animations.scss
+++ b/src/pivotal-ui/components/react-animations/react-animations.scss
@@ -2,28 +2,9 @@
 @import '../mixins';
 @import "../../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/mixins";
 
-
 .new-enter {
   -webkit-animation: new-item-grow .3s cubic-bezier(0.895, 0.03, 0.685, 0.22) forwards, new-item-fade .5s ease-in .15s forwards;
   -moz-animation: new-item-grow .3s cubic-bezier(0.895, 0.03, 0.685, 0.22) forwards, new-item-fade .5s ease-in .15s forwards;
-}
-
-.expander-enter {
-  @include transition-pui(max-height, 0.75s, ease);
-  max-height: 0;
-}
-
-.expander-enter-active {
-  max-height: 500px;
-}
-
-.expander-leave {
-  @include transition-pui(max-height, 0.75s, ease);
-  max-height: 500px;
-}
-
-.expander-leave-active {
-  max-height: 0;
 }
 
 @-webkit-keyframes new-item-fade {


### PR DESCRIPTION
Before, with large content, the expander would open smoothly for some
percentage of the distance and then suddenly jump the rest.

The expander component now has a new css dependency (`pui-css-bootstrap`). This is because the expander now relies on bootstrap's collapse animation to be less janky.
