### PR TITLE
fix(alerts): Remove extra margin on the alert

### DIFF
--- a/src/pivotal-ui-react/alerts/alerts.js
+++ b/src/pivotal-ui-react/alerts/alerts.js
@@ -32,7 +32,7 @@ var Alert = React.createClass({
 
       if (withIcon) {
         var icon = <i className={`fa ${alertIcon}`}></i>;
-        children = <Media leftImage={icon}>{children}</Media>;
+        children = <Media className={'mtn'} leftImage={icon}>{children}</Media>;
       }
       return <BsAlert {...others} onDismiss={onDismiss}>{children}</BsAlert>;
     }

--- a/src/pivotal-ui/components/alerts/alerts.scss
+++ b/src/pivotal-ui/components/alerts/alerts.scss
@@ -62,7 +62,7 @@ Our 4 alert types are:
 
 ```html_example_table
 <div class="alert alert-success">
-  <div class="media">
+  <div class="media mtn">
     <div class="media-left">
       <i class="fa fa-check-circle"></i>
     </div>
@@ -74,7 +74,7 @@ Our 4 alert types are:
 </div>
 
 <div class="alert alert-info">
-  <div class="media">
+  <div class="media mtn">
     <div class="media-left">
       <i class="fa fa-info-circle"></i>
     </div>
@@ -86,7 +86,7 @@ Our 4 alert types are:
 </div>
 
 <div class="alert alert-warning">
-  <div class="media">
+  <div class="media mtn">
     <div class="media-left">
       <i class="fa fa-exclamation-triangle"></i>
     </div>
@@ -98,7 +98,7 @@ Our 4 alert types are:
 </div>
 
 <div class="alert alert-error">
-  <div class="media">
+  <div class="media mtn">
     <div class="media-left">
       <i class="fa fa-exclamation-triangle"></i>
     </div>
@@ -172,9 +172,6 @@ other content inside a container on the page (of a width 500px for this example)
     text-decoration: none;
     line-height: .7;
     text-shadow: none;
-    + .media {
-      margin-top: 0;
-    }
   }
 }
 

--- a/src/pivotal-ui/components/alerts/alerts.scss
+++ b/src/pivotal-ui/components/alerts/alerts.scss
@@ -172,6 +172,9 @@ other content inside a container on the page (of a width 500px for this example)
     text-decoration: none;
     line-height: .7;
     text-shadow: none;
+    + .media {
+      margin-top: 0;
+    }
   }
 }
 


### PR DESCRIPTION
When the close button is followed by a media component, the margin
should be cleared. There is a special rule that handled this for alerts
inside a table which is how it is shown in the styleguide.