### PR TITLE
feat(mixin): Removed font mixin from mixins.scss

### DIFF
--- a/src/pivotal-ui/components/mixins.scss
+++ b/src/pivotal-ui/components/mixins.scss
@@ -118,21 +118,6 @@
   background-clip: padding-box;      /* Firefox 4, Safari 5, Opera 10, IE 9 */
 }
 
-// Source sans pro mixin
-
-@mixin font($name, $weight, $style) {
-  @font-face {
-    font-family: 'SourceSansPro';
-    src: url("fonts/#{$name}.eot");
-    src: url("fonts/#{$name}.eot?#iefix") format("embedded-opentype"),
-    url("fonts/#{$name}.woff") format("woff"),
-    url("fonts/#{$name}.ttf") format("truetype"),
-    url("fonts/#{$name}.svg##{$name}") format("svg");
-    font-weight: $weight;
-    font-style: $style;
-  }
-}
-
 @mixin h1() {
   //bootstrap
   font-family: $headings-font-family;


### PR DESCRIPTION
This was a duplicate mixin with font-helper in typography.scss which was
not being used internally.

[Finishes #98963152]

BREAKING CHANGE: (scss mixin): font() mixin no longer available. Use
font-helper mixin from pui-css-typography instead.