### PR TITLE
chore(documentation): Fix package name in UI Variables and Mixins README

### DIFF
--- a/PUI_VARIABLES_AND_MIXINS_README.md
+++ b/PUI_VARIABLES_AND_MIXINS_README.md
@@ -5,10 +5,10 @@
 ## Usage
 
 ```sh
-npm install pui-variables-and-mixins
+npm install pui-css-variables-and-mixins
 ```
 
-After installing, the files will be located in the `node_modules/pui-variables-and-mixins/` directory
+After installing, the files will be located in the `node_modules/pui-css-variables-and-mixins/` directory
 
 
 *****************************************


### PR DESCRIPTION
The name of npm package is `pui-css-variables-and-mixins`.