### PR TITLE
fix(draggable-list): draggable list callback is fixed

### DIFF
--- a/spec/pivotal-ui-react/draggable-list/draggable-list_spec.js
+++ b/spec/pivotal-ui-react/draggable-list/draggable-list_spec.js
@@ -2,12 +2,12 @@ require('../spec_helper');
 import {itPropagatesAttributes} from '../support/shared_examples';
 
 describe('DraggableList', function() {
-  var DraggableList, DraggableListItem, subject, dropSpy, props;
+  var DraggableList, DraggableListItem, subject, dragEndSpy, props;
   beforeEach(function() {
     DraggableList = require('../../../src/pivotal-ui-react/draggable-list/draggable-list').DraggableList;
     DraggableListItem = require('../../../src/pivotal-ui-react/draggable-list/draggable-list').DraggableListItem;
 
-    dropSpy = jasmine.createSpy('drop');
+    dragEndSpy = jasmine.createSpy('dragEnd');
 
     props = {
       className: 'test-class',
@@ -18,7 +18,7 @@ describe('DraggableList', function() {
     };
 
     subject = React.render(
-      <DraggableList onDrop={dropSpy} {...props} innerClassName='inner-test-class'>
+      <DraggableList onDragEnd={dragEndSpy} {...props} innerClassName='inner-test-class'>
         <DraggableListItem>
           Get me out of here!
         </DraggableListItem>
@@ -153,13 +153,14 @@ describe('DraggableList', function() {
         expect(getListItemText()).toEqual(['LOL', 'Get me out of here!', 'Can\'t stop']);
       });
 
-      describe('when the drop event is triggered', function() {
+      describe('when the dragEnd event is triggered', function() {
         beforeEach(function() {
-          $('li.list-group-item:eq(1)').simulate('drop', {dataTransfer: dataTransferSpy});
+          $('li.list-group-item:eq(1)').simulate('dragEnd', {dataTransfer: dataTransferSpy});
         });
 
-        it('calls the drop callback', function() {
-          expect(dropSpy).toHaveBeenCalledWith([1, 0, 2]);
+        it('calls the dragEnd callback only once', function() {
+          expect(dragEndSpy).toHaveBeenCalledWith([1, 0, 2]);
+          expect(dragEndSpy.calls.count()).toEqual(1);
         });
       });
 

--- a/src/pivotal-ui-react/draggable-list/draggable-list.js
+++ b/src/pivotal-ui-react/draggable-list/draggable-list.js
@@ -52,7 +52,7 @@ function childrenIndices(children) {
  */
 var DraggableList = React.createClass({
   propTypes: {
-    onDrop: types.func,
+    onDragEnd: types.func,
     innerClassName: types.string
   },
 
@@ -61,7 +61,6 @@ var DraggableList = React.createClass({
       itemIndices: childrenIndices(this.props.children),
       draggingId: null
     };
-
   },
 
   componentWillReceiveProps(nextProps) {
@@ -82,6 +81,7 @@ var DraggableList = React.createClass({
 
   dragEnd() {
     this.setState({draggingId: null});
+    this.props.onDragEnd && this.props.onDragEnd(this.state.itemIndices);
   },
 
   dragEnter(e) {
@@ -96,13 +96,9 @@ var DraggableList = React.createClass({
     this.setState({itemIndices});
   },
 
-  drop() {
-    this.props.onDrop && this.props.onDrop(this.state.itemIndices);
-  },
-
   render() {
     var grabbed, items = [];
-    var {children, innerClassName, ...others} = this.props;
+    var {children, innerClassName, onDragEnd, ...others} = this.props;
     React.Children.forEach(children, function(child, draggingId) {
       grabbed = this.state.draggingId === draggingId;
       items.push(React.addons.cloneWithProps(child, {
@@ -110,7 +106,6 @@ var DraggableList = React.createClass({
         onDragStart: this.dragStart.bind(this, draggingId),
         onDragEnd: this.dragEnd,
         onDragEnter: this.dragEnter,
-        onDrop: this.drop,
         draggingId,
         key: draggingId,
         className: innerClassName
@@ -142,19 +137,18 @@ var DraggableListItem = React.createClass({
     onDragStart: types.func,
     onDragEnter: types.func,
     onDragEnd: types.func,
-    onDrop: types.func,
     grabbed: types.bool,
     className: types.string
   },
 
   render() {
     var {hover} = this.state;
-    var {grabbed, onDragStart, onDragEnd, onDragEnter, onDrop, draggingId} = this.props;
+    var {grabbed, onDragStart, onDragEnd, onDragEnter, draggingId} = this.props;
     var {onMouseEnter, onMouseLeave} = this;
     var className = classnames({'list-group-item pan': true, grabbed, hover});
     var innerClassName = classnames(this.props.className, 'draggable-item-content');
     var props = {
-      className, onMouseEnter, onMouseLeave, onDragStart, onDragEnd, onDragEnter, onDrop,
+      className, onMouseEnter, onMouseLeave, onDragStart, onDragEnd, onDragEnter,
       onDragOver: preventDefault,
       draggable: !grabbed,
       'data-dragging-id': draggingId
@@ -186,17 +180,17 @@ parent: list_react
 
 Creates a draggable list.
 
-The property `onDrop` is a callback when a drop event has completed. Use this
+The property `onDragEnd` is a callback when a drag event has completed. Use this
 if you need to make an API call to update the order of some elements.
 
 ```jsx_example
-var draggableListDropCallback = function(data) {
+var dragEndCallback = function(data) {
   alert('New item indices order: ' + data);
 };
 ```
 
 ```react_example
-<DraggableList onDrop={draggableListDropCallback} className="my-list-class" innerClassName="my-item-class">
+<DraggableList onDragEnd={dragEndCallback} className="my-list-class" innerClassName="my-item-class">
   <DraggableListItem>
     Get me out of here!
   </DraggableListItem>
@@ -207,6 +201,18 @@ var draggableListDropCallback = function(data) {
 
   <DraggableListItem>
     Can't stop
+  </DraggableListItem>
+
+  <DraggableListItem>
+   Get me out of here!
+  </DraggableListItem>
+
+  <DraggableListItem>
+   LOL
+  </DraggableListItem>
+
+  <DraggableListItem>
+   Can't stop
   </DraggableListItem>
 </DraggableList>
 ```


### PR DESCRIPTION
* callback is only called once per drag
* callback is called on dragEnd instead of drop so that it is called even
 when the mouse is outside of the list

[Finishes #102532202]

Signed-off-by: Claire Thompson <cthompson@pivotal.io>

BREAKING CHANGE: DraggableList callback onDrop is no longer passed to
list items - use onDragEnd instead to provide a callback.