### PR TITLE
fix(autocomplete): withRelatedTarget now merges properties in correct order

### DIFF
--- a/src/pivotal-ui-react/autocomplete/autocomplete-input.js
+++ b/src/pivotal-ui-react/autocomplete/autocomplete-input.js
@@ -20,7 +20,8 @@ function waitForRelatedTarget() {
 function withRelatedTarget(callback) {
   return async function(e) {
     if (!e.relatedTarget) {
-      e = {relatedTarget: await waitForRelatedTarget.call(this), ...e};
+      e = {...e};
+      e.relatedTarget = await waitForRelatedTarget.call(this);
     }
     return callback.call(this, e);
   };


### PR DESCRIPTION
fix(autocomplete): withRelatedTarget now merges properties in correct order

This fixes an issue in Firefox and Safari where clicking an Autocomplete
list item closed the list without calling the proper pick function.

This happened because the Autocomplete Input's blur function was
incorrectly making it to its last line which hides the list before that
pick function could be called. It was making it past the intended early
return condition because relatedTarget was null (except in Chrome).
relatedTarget was null because a object full of null properties
was merging on top of the actual relatedTarget in the withRelatedTarget
helper function.

[#101461670]