### PR TITLE
Add lodash.uniqueid dependency for dropdowns

### DIFF
--- a/src/pivotal-ui-react/dropdowns/package.json
+++ b/src/pivotal-ui-react/dropdowns/package.json
@@ -8,6 +8,7 @@
     "pui-css-iconography": "2.0.0-alpha.4",
     "pui-css-buttons": "2.0.0-alpha.4",
     "pui-css-button-group": "2.0.0-alpha.4",
-    "classnames": "^2.1.2"
+    "classnames": "^2.1.2",
+    "lodash.uniqueid": "3.0.0"
   }
 }


### PR DESCRIPTION
dropdowns also requires the lodash.uniqueid module (which is not part of lodash) to work and this commit prevents users from having to explicitly require it.

Fixes issue stated in comment here: https://github.com/pivotal-cf/pivotal-ui/pull/250