### PR TITLE
Fixes #263

### DIFF
--- a/src/pivotal-ui/components/button-group/button-group.scss
+++ b/src/pivotal-ui/components/button-group/button-group.scss
@@ -30,7 +30,6 @@ Button groups wrap a series of buttons.
   .btn {
     &.active, &:active {
       color: $neutral-11;
-      background-color: $btn-default-color;
     }
   }
 }


### PR DESCRIPTION
The dropdown component automatically seems to use button groups, which will turn blue when any button in the group is clicked and held on (or for a brief moment when it is clicked and considered active). This commit removes the background so no blue flashing/background color appears.