### PR TITLE
fix(dependency): remove unused font-awesome dependency for pui-css-typography

### DIFF
--- a/src/pivotal-ui/components/typography/package.json
+++ b/src/pivotal-ui/components/typography/package.json
@@ -1,8 +1,7 @@
 {
   "homepage": "http://styleguide.pivotal.io/",
   "dependencies": {
-    "pui-css-bootstrap": "2.1.0-alpha.1",
-    "font-awesome": "^4.4.0"
+    "pui-css-bootstrap": "2.1.0-alpha.1"
   },
   "version": "2.1.0-alpha.1"
 }


### PR DESCRIPTION
Pivotal-ui-charts is trying to remove font-awesome, since it doubles the size of our app. We've removed it everywhere except that it remains a subdependency of pui-css-typography which we still need. Pui-css-typography does not appear to use font-awesome so we would like to remove it.