### PR TITLE
Allow Panels to have full headers

### DIFF
--- a/library/spec/pivotal-ui-react/panels/panels_spec.js
+++ b/library/spec/pivotal-ui-react/panels/panels_spec.js
@@ -30,20 +30,34 @@ describe('Panel', function() {
   });
 
   describe('when a title is provided', function() {
-    beforeEach(function() {
-      ReactDOM.render(<Panel title="This is a title">Sup</Panel>, root);
+    describe('when the title is a string', function() {
+      beforeEach(function() {
+        ReactDOM.render(<Panel title="This is a title">Sup</Panel>, root);
+      });
+
+      it('sets the title to the panel', function() {
+        expect('.panel .panel-header .panel-title-alt').toContainText('This is a title');
+      });
     });
 
-    it('sets the title to the panel', function() {
-      expect('.panel .panel-header .panel-title-alt').toContainText('This is a title');
+    describe('when the title is a node', function() {
+      beforeEach(function() {
+        const title = <div className="hey">HEY</div>;
+        ReactDOM.render(<Panel title={title}>Sup</Panel>, root);
+      });
+
+      it('renders the contents without .panel-title-alt', function() {
+        expect('.panel .panel-header .hey').toContainText('HEY');
+        expect('.panel .panel-header .panel-title-alt').not.toExist();
+      });
     });
   });
 
   describe('when attributes are provided', function() {
     beforeEach(function() {
       ReactDOM.render(<Panel className="foo myClass" innerClassName="inner-class"
-                          id="outer-id"
-                          style={{opacity: '0.5'}}>Sup</Panel>, root);
+                             id="outer-id"
+                             style={{opacity: '0.5'}}>Sup</Panel>, root);
     });
 
     it('sets className, id, and style on the panel outer div', function() {
@@ -120,6 +134,24 @@ describe('Panel', function() {
     });
   });
 
+  describe('PanelTitle', function() {
+    let clickSpy;
+    beforeEach(function() {
+      clickSpy = jasmine.createSpy('click');
+      const PanelTitle = require('../../../src/pivotal-ui-react/panels/panels').PanelTitle;
+      ReactDOM.render(<PanelTitle className="extra-class" onClick={clickSpy}>Titlist</PanelTitle>, root);
+    });
+
+    it('renders as a panel-title-alt', function() {
+      expect('.panel-title-alt').toHaveText('Titlist');
+    });
+
+    it('passes props through, including classname', function() {
+      expect('.panel-title-alt').toHaveClass('extra-class');
+      $('.panel-title-alt').simulate('click');
+      expect(clickSpy).toHaveBeenCalled();
+    });
+  });
 });
 
 describe('ShadowPanel', function() {

--- a/library/src/pivotal-ui-react/panels/panels.js
+++ b/library/src/pivotal-ui-react/panels/panels.js
@@ -1,15 +1,15 @@
-var React = require('react');
-var types = React.PropTypes;
-var classnames = require('classnames');
+const React = require('react');
+const types = React.PropTypes;
+const classnames = require('classnames');
 import {mergeProps} from 'pui-react-helpers';
 
-var paddingTypes = [
+const paddingTypes = [
   for (type of ['p', 'm'])
   for (location of ['l', 'r', 't', 'b', 'h', 'v', 'a'])
   for (size of ['n', 's', 'm', 'l', 'xl', 'xxl', 'xxxl', 'xxxxl'])
   `${type}${location}${size}`
   ];
-var PanelTypes = {
+const PanelTypes = {
   propTypes: {
     type: types.string,
     innerClassName: types.string,
@@ -24,6 +24,41 @@ var PanelTypes = {
     ])
   }
 };
+
+const PanelTitle = React.createClass({
+  propTypes: {
+    className: types.string
+  },
+
+  render() {
+    let {className, ...other} = this.props;
+    className = classnames('panel-title-alt', className);
+    return <div {...{className}} {...other}/>;
+  }
+});
+
+const PanelHeader = React.createClass({
+  propTypes: {
+    title: types.node
+  },
+
+  render() {
+    const {title} = this.props;
+    if(title) {
+      var titleNode = title.constructor === String ?
+        (<PanelTitle>{title}</PanelTitle>) :
+        title;
+
+      return (
+        <div className="panel-header">
+          {titleNode}
+        </div>
+      );
+    } else {
+      return null;
+    }
+  }
+});
 
 /**
  * @component Panel
@@ -41,12 +76,10 @@ var PanelTypes = {
  * ```
  *
  */
-var Panel = React.createClass({
-
+const Panel = React.createClass({
   propTypes: {
     kind: types.string,
-    title: types.string,
-    type: types.string,
+    title: types.node,
     innerClassName: types.string,
     padding: function(props, propName, componentName) {
       if (props.padding && !props.padding.split(' ').every(pad => paddingTypes.indexOf(pad) >= 0)) {
@@ -60,22 +93,16 @@ var Panel = React.createClass({
   },
 
   render() {
-   const {kind, innerClassName, padding, scrollable, children, ...other} = this.props;
+    const {title, kind, innerClassName, padding, scrollable, children, ...other} = this.props;
     const panelStyle = (typeof scrollable === 'number') ? {maxHeight: `${scrollable}px`} : null;
     const props = mergeProps(other, {
       className: ['panel', kind, {'panel-scrollable': scrollable}],
       style: panelStyle
     });
 
-    const title = this.props.title ? (
-      <div className="panel-header">
-        <h5 className="panel-title-alt">{this.props.title}</h5>
-      </div>
-    ) : null;
-
     return (
       <div {...props}>
-        {title}
+        <PanelHeader title={title}/>
         <div className={classnames('panel-body', padding, innerClassName)}>{children}</div>
       </div>
     );
@@ -90,7 +117,7 @@ var Panel = React.createClass({
  * @property shadowLevel {Number} The thickness (1-4) (defaults to `3`) of the shadow
  *
  */
-var ShadowPanel = React.createClass({
+const ShadowPanel = React.createClass({
   mixins: [PanelTypes],
 
   propTypes: {
@@ -173,5 +200,7 @@ module.exports = {
    */
   HighlightPanel: defPanel({kind: 'panel-highlight'}),
 
-  ShadowPanel
+  ShadowPanel,
+
+  PanelTitle
 };

--- a/library/src/pivotal-ui/components/panels/panels.scss
+++ b/library/src/pivotal-ui/components/panels/panels.scss
@@ -29,14 +29,17 @@
   border-bottom: 2px solid $shadow-3;
 }
 
-.panel-title-alt {
+.panel-header {
   padding: $panel-title-padding;
   border-bottom: $panel-title-border;
-  font-weight: $panel-title-font-weight;
-  color: $panel-title-text;
 }
 
-
+.panel-title-alt {
+  color: $panel-title-text;
+  font-weight: $panel-title-font-weight;
+  font-size: $panel-title-font-size;
+  line-height: $headings-line-height;
+}
 
 .panel-basic-alt {
   border: $panel-basic-alt-border;

--- a/styleguide/docs/css/panels.scss
+++ b/styleguide/docs/css/panels.scss
@@ -49,7 +49,7 @@ By default, all the .panel does is apply a basic shadow and padding to contain s
 ```html_example
 <div class="panel panel-basic bg-neutral-11">
   <div class="panel-header">
-    <h5 class="panel-title-alt">Basic Title</h5>
+    <div class="panel-title-alt">Basic Title</div>
   </div>
   <div class="panel-body">
     Basic Panel
@@ -77,7 +77,7 @@ Basic alternate panels are panels with a border and shadow. You can have a panel
 ```html_example
 <div class="panel panel-basic-alt">
   <div class="panel-header">
-    <h5 class="panel-title-alt">Basic Title Alt</h5>
+    <div class="panel-title-alt">Basic Title Alt</div>
   </div>
   <div class="panel-body">
     Basic Panel

--- a/styleguide/docs/react/panels.js
+++ b/styleguide/docs/react/panels.js
@@ -22,6 +22,7 @@ var BasicPanel = require('pui-react-panels').BasicPanel;
 var ClickablePanel = require('pui-react-panels').ClickablePanel;
 var ClickableAltPanel = require('pui-react-panels').ClickableAltPanel;
 var HighlightPanel = require('pui-react-panels').HighlightPanel;
+var PanelTitle = require('pui-react-panels').PanelTitle;
 var ScrollablePanel = require('pui-react-panels').ScrollablePanel;
 var ShadowPanel = require('pui-react-panels').ShadowPanel;
 var SimplePanel = require('pui-react-panels').SimplePanel;
@@ -34,14 +35,23 @@ is the base, and there are many different flavors of Panels which all construct 
 See examples below.
 
 ```react_example_table
-<Panel className="bg-neutral-8">
+<Panel className="bg-neutral-10">
   <p>Base Panel</p>
 </Panel>
 
-<Panel className="bg-neutral-8 optional-class"
+<Panel className="bg-neutral-10 optional-class"
   innerClassName="opt-inner-class">
   <p>Base Panel</p>
 </Panel>
+
+<Panel className="bg-neutral-10" title='title'>
+ Base Panel with base title
+</Panel>
+
+<Panel className="bg-neutral-10" title={<h2>Custom Title</h2>}>
+ Base Panel with custom title
+</Panel>
+
 ```
 */
 
@@ -143,6 +153,29 @@ parent: panel_react
 
 <BasicPanelAlt title='Basic Alt Title'>
   Basic Panel
+</BasicPanelAlt>
+```
+*/
+
+/*doc
+---
+title: Panel Title
+name: panel_title_react
+parent: panel_react
+---
+
+All Panels accept a `title` property. If `title` is a string, it will render a title with some
+default styling using the `PanelTitle` component internally. If `title` is a react component,
+it will render the component without additional style.
+To create a title with some default title styling, use the `PanelTitle` component.
+
+```react_example_table
+<BasicPanelAlt title={
+      <div>
+        <PanelTitle>Panel Title</PanelTitle>subtitle
+      </div>
+    }>
+  Basic Panel With Custom Title
 </BasicPanelAlt>
 ```
 */


### PR DESCRIPTION
See issue #318, #285 

Panels can receive a `title` prop that is either a string or a React Component

