### PR TITLE
fix(autocomplete): Use onfocusout instead of onBlur, for Safari support

### DIFF
--- a/library/spec/pivotal-ui-react/autocomplete/autocomplete_spec.js
+++ b/library/spec/pivotal-ui-react/autocomplete/autocomplete_spec.js
@@ -88,14 +88,17 @@ describe('Autocomplete', function() {
     });
 
     describe('when the blur event is triggered', function() {
-      beforeEach(function(done) {
-        jasmine.clock().uninstall();
-        $('.autocomplete input').simulate('blur');
-        setTimeout(function() { done(); }, 100);
-      });
-
-      afterEach(function() {
-        jasmine.clock().install();
+      beforeEach(function() {
+        ReactDOM.render(
+          <div>
+            <Autocomplete {...{onPick: pickSpy, onInitializeItems, maxItems: 2}}/>
+            <input className="anything-else"/>
+          </div>,
+          root
+        );
+        $('.autocomplete input').val('wat').simulate('change');
+        jasmine.clock().tick(1);
+        $('.anything-else').simulate('focus');
       });
 
       it('hides the list', function() {

--- a/library/src/pivotal-ui-react/autocomplete/autocomplete-input.js
+++ b/library/src/pivotal-ui-react/autocomplete/autocomplete-input.js
@@ -9,24 +9,6 @@ const ESC_KEY = 27;
 const TAB_KEY = 9;
 const UP_KEY = 38;
 
-function waitForRelatedTarget() {
-  return new Promise(function(resolve) {
-    setImmediate(() => {
-      resolve(document.activeElement);
-    });
-  });
-}
-
-function withRelatedTarget(callback) {
-  return async function(e) {
-    if (!e.relatedTarget) {
-      e = {...e};
-      e.relatedTarget = await waitForRelatedTarget.call(this);
-    }
-    return callback.call(this, e);
-  };
-}
-
 var AutocompleteInput = React.createClass({
   propTypes: {
     $autocomplete: types.object,
@@ -56,10 +38,9 @@ var AutocompleteInput = React.createClass({
     return {autoFocus: null};
   },
 
-  blur: withRelatedTarget(function({relatedTarget}) {
-    if (relatedTarget && relatedTarget.classList && relatedTarget.classList.contains('autocomplete-item')) return;
+  blur() {
     this.props.hideList();
-  }),
+  },
 
   change(e) {
     var {value} = e.currentTarget;
@@ -114,7 +95,7 @@ var AutocompleteInput = React.createClass({
     var {autoFocus, children, $autocomplete, ...props} = this.props;
     if (!$autocomplete) return null;
     var {value} = $autocomplete.get();
-    var otherProps = {autoFocus, value, onBlur: this.blur, onChange: this.change, onKeyDown: this.keyDown};
+    var otherProps = {autoFocus, value, onfocusout: this.blur, onChange: this.change, onKeyDown: this.keyDown};
     props = {...props, ...otherProps};
     if (!children) return this.renderDefault(props);
     children = React.Children.map(children, e => React.cloneElement(e, props));


### PR DESCRIPTION
We noticed that the autocomplete list would close before the click event on the list item could trigger. This was because relatedTarget of the blur event in Safari doesn't work correctly - it returns the HTML body instead of the list item. If onfocusout is used instead of React's onBlur, the relatedTarget property of the event works in Safari.

Signed-off-by: Douglas Blumeyer <dblumeyer@pivotal.io>