### PR TITLE
Fix TileLayout on Styleguide Home Page

### DIFF
--- a/styleguide/src/intro-page.js
+++ b/styleguide/src/intro-page.js
@@ -2,7 +2,7 @@ const React = global.React || require('react');
 const BasePane = global.BasePane || require('pui-react-panes').BasePane;
 const Button = global.DefaultButton || require('pui-react-buttons').DefaultButton;
 const TileLayout = global.TileLayout || require('pui-react-tile-layout');
-const TileLayoutItem = global.TileLayout || require('pui-react-tile-layout');
+const TileLayoutItem = global.TileLayoutItem || require('pui-react-tile-layout');
 
 const IntroPage = React.createClass({
   render() {


### PR DESCRIPTION
Regarding: #374

Including TileLayoutItem seemed to do the trick:

`const TileLayoutItem = global.TileLayoutItem || require('pui-react-tile-layout');`

@charleshansen 