### PR TITLE
feat(dropdowns): React Dropdown does not need a title

### DIFF
--- a/library/spec/pivotal-ui-react/dropdown/dropdown_spec.js
+++ b/library/spec/pivotal-ui-react/dropdown/dropdown_spec.js
@@ -1,19 +1,19 @@
 require('../spec_helper');
 import {Dropdown, DropdownItem} from '../../../src/pivotal-ui-react/dropdowns/dropdowns';
 
-describe('Dropdowns', function() {
+describe('Dropdowns', () => {
   function dropdownTestFor(dropdownComponentName, dropdownClassName) {
-    describe(dropdownComponentName, function() {
-      beforeEach(function() {
+    describe(dropdownComponentName, () => {
+      beforeEach(() => {
         var DropdownClass = require('../../../src/pivotal-ui-react/dropdowns/dropdowns')[dropdownComponentName];
         ReactDOM.render(<DropdownClass title="Dropping" buttonClassName="test-btn-class"/>, root);
       });
 
-      afterEach(function() {
+      afterEach(() => {
         ReactDOM.unmountComponentAtNode(root);
       });
 
-      it('creates a dropdown', function() {
+      it('creates a dropdown', () => {
         expect('button.dropdown-toggle').toContainText('Dropping');
       });
 
@@ -25,10 +25,10 @@ describe('Dropdowns', function() {
     });
   }
 
-  describe('Dropdown', function() {
-    let subject
+  describe('Dropdown', () => {
+    let subject;
 
-    beforeEach(function() {
+    beforeEach(() => {
       const props = {
         className: 'test-class',
         id: 'test-id',
@@ -37,66 +37,154 @@ describe('Dropdowns', function() {
         }
       };
 
-
       subject = ReactDOM.render(
         <Dropdown title="Dropping" {...props} buttonClassName="test-btn-class">
           <DropdownItem href="test">Item #1</DropdownItem>
         </Dropdown>, root);
     });
 
-    afterEach(function() {
+    afterEach(() => {
       ReactDOM.unmountComponentAtNode(root);
     });
 
-    it('passes through className to the dropdown', function() {
+    it('passes through className to the dropdown', () => {
       expect('.dropdown').toHaveClass('test-class');
     });
 
-    it('passes through style to the button', function() {
+    it('passes through style to the button', () => {
       expect('.dropdown-toggle').toHaveCss({opacity: '0.5'});
     });
 
-    it('passes through id to the button', function() {
+    it('passes through id to the button', () => {
       expect('.dropdown-toggle#test-id').toExist();
     });
 
     it('creates a dropdown-toggle', () => {
       expect('.dropdown-toggle').toContainText('Dropping');
-      expect('.dropdown-toggle').toHaveClass('btn-default');
       expect('.dropdown-toggle').toHaveClass('test-btn-class');
     });
 
-    it('renders all children DropdownItems', function() {
-      expect('.dropdown-menu li').toHaveLength(1);
-      expect('.dropdown-menu li').toHaveText('Item #1');
-    });
-
-    describe('split', () => {
-      it('puts the title in the dropdown label when split is true', () => {
-        subject::setProps({split: true});
-        expect('.dropdown-label').toHaveText('Dropping');
-        expect('.dropdown-toggle').not.toHaveText('Dropping');
+    describe('dropdown menu', () => {
+      it('shows the children on click', () => {
+        expect('.dropdown-menu').not.toExist();
+        $('.dropdown-toggle').simulate('click');
+        expect('.dropdown-menu li').toHaveLength(1);
+        expect('.dropdown-menu li').toHaveText('Item #1');
       });
 
-      it('puts the title in the dropdown toggle when split is false', () => {
-        subject::setProps({split: false});
-        expect('.dropdown-toggle').toHaveText('Dropping');
+      describe('hiding children', () => {
+        it('hides when the toggle is clicked', () => {
+          $('.dropdown-toggle').simulate('click');
+          expect('.dropdown-menu').toExist();
+          $('.dropdown-toggle').simulate('click');
+          expect('.dropdown-menu').not.toExist();
+        });
+
+        it('hides when clicking outside the dropdown', () => {
+          $('.dropdown-toggle').simulate('click');
+          expect('.dropdown-menu').toExist();
+          const evt = document.createEvent('HTMLEvents');
+          evt.initEvent('click', true, true );
+          document.documentElement.dispatchEvent(evt);
+          expect('.dropdown-menu').not.toExist();
+        });
+
+        describe('when scrim is disabled', () => {
+          it('does not hide the dropdown menu when clicking outside of the dropdown', () => {
+            subject::setProps({disableScrim: true});
+
+            $('.dropdown-toggle').simulate('click');
+            expect('.dropdown-menu').toExist();
+            const evt = document.createEvent('HTMLEvents');
+            evt.initEvent('click', true, true );
+            document.documentElement.dispatchEvent(evt);
+            expect('.dropdown-menu').toExist();
+          });
+        });
       });
     });
 
-    describe('toggle', () => {
+    describe('when title is provided', () => {
       beforeEach(() => {
-        subject::setProps({title: 'Dropping', toggle: <div className="foo">Toggle!</div>});
+        subject = ReactDOM.render(
+          <Dropdown title="Dropping" buttonClassName="test-btn-class">
+            <DropdownItem href="test">Item #1</DropdownItem>
+          </Dropdown>, root);
       });
 
-      it('puts the title in the dropdown label', () => {
-        expect('.dropdown-label').toHaveText('Dropping');
-        expect('.dropdown-toggle').not.toHaveText('Dropping');
+      describe('when toggle is not set', () => {
+        describe('when split is false', () => {
+          it('puts the title in the dropdown toggle', () => {
+            expect('.dropdown-label').not.toExist();
+            expect('.dropdown-toggle').toHaveText('Dropping');
+          });
+        });
+
+        describe('when split is true', () => {
+          beforeEach(() => {
+            subject::setProps({split: true});
+          });
+
+          it('puts the title in the dropdown label', () => {
+            expect('.dropdown-label').toHaveText('Dropping');
+            expect('.dropdown-toggle').not.toHaveText('Dropping');
+          });
+        });
       });
 
-      it('puts the custom toggle in the dropdown toggle', () => {
-        expect('.dropdown-label').not.toHaveText('Toggle!');
-        expect('.dropdown-toggle').toHaveText('Toggle!');
+      describe('when toggle is set', () => {
+        beforeEach(() => {
+          subject::setProps({toggle: <div className="foo">★</div>});
+        });
+
+        describe('when split is false', () => {
+          it('puts the title in the dropdown toggle', () => {
+            expect('.dropdown-label').not.toExist();
+            expect('.dropdown-toggle').toHaveText('Dropping★');
+          });
+        });
+
+        describe('when split is true', () => {
+          beforeEach(() => {
+            subject::setProps({split: true});
+          });
+
+          it('puts the title in the dropdown label', () => {
+            expect('.dropdown-label').toHaveText('Dropping');
+            expect('.dropdown-toggle').toHaveText('★');
+          });
+        });
+      });
+    });
+
+    describe('when title is not provided', () => {
+      beforeEach(() => {
+        subject = ReactDOM.render(
+          <Dropdown buttonClassName="test-btn-class">
+            <DropdownItem href="test">Item #1</DropdownItem>
+          </Dropdown>, root
+        );
+      });
+
+      describe('when toggle is not set', () => {
+        describe('when split is false', () => {
+          it('renders the default toggle with no label', () => {
+            expect('.dropdown-label').not.toExist();
+            expect('.dropdown-toggle').toExist();
+          });
+        });
+      });
+
+      describe('when toggle is set', () => {
+        beforeEach(() => {
+          subject::setProps({toggle: <div className="foo">★</div>});
+        });
+        describe('when split is false', () => {
+          it('renders the custom toggle with no label', () => {
+            expect('.dropdown-label').not.toExist();
+            expect('.dropdown-toggle .foo').toHaveText('★');
+          });
+        });
       });
     });
   });

--- a/library/spec/pivotal-ui-react/dropdown/dropdown_spec.js
+++ b/library/spec/pivotal-ui-react/dropdown/dropdown_spec.js
@@ -101,6 +101,22 @@ describe('Dropdowns', () => {
           });
         });
       });
+
+      describe('when border is provided', () => {
+        it('has the border class', () => {
+          subject::setProps({border: true});
+          $('.dropdown-toggle').simulate('click');
+          expect('.dropdown-menu.dropdown-border').toExist();
+        });
+      });
+
+      describe('when pullRight is provided', () => {
+        it('has the pull right class', () => {
+          subject::setProps({pullRight: true});
+          $('.dropdown-toggle').simulate('click');
+          expect('.dropdown-menu.dropdown-menu-right').toExist();
+        })
+      })
     });
 
     describe('when title is provided', () => {

--- a/library/spec/pivotal-ui-react/dropdown/dropdown_spec.js
+++ b/library/spec/pivotal-ui-react/dropdown/dropdown_spec.js
@@ -66,27 +66,26 @@ describe('Dropdowns', () => {
 
     describe('dropdown menu', () => {
       it('shows the children on click', () => {
-        expect('.dropdown-menu').not.toExist();
+        expect('.open .dropdown-menu').not.toExist();
         $('.dropdown-toggle').simulate('click');
-        expect('.dropdown-menu li').toHaveLength(1);
-        expect('.dropdown-menu li').toHaveText('Item #1');
+        expect('.open .dropdown-menu').toExist();
       });
 
       describe('hiding children', () => {
         it('hides when the toggle is clicked', () => {
           $('.dropdown-toggle').simulate('click');
-          expect('.dropdown-menu').toExist();
+          expect('.open .dropdown-menu').toExist();
           $('.dropdown-toggle').simulate('click');
-          expect('.dropdown-menu').not.toExist();
+          expect('.open .dropdown-menu').not.toExist();
         });
 
         it('hides when clicking outside the dropdown', () => {
           $('.dropdown-toggle').simulate('click');
-          expect('.dropdown-menu').toExist();
+          expect('.open .dropdown-menu').toExist();
           const evt = document.createEvent('HTMLEvents');
           evt.initEvent('click', true, true );
           document.documentElement.dispatchEvent(evt);
-          expect('.dropdown-menu').not.toExist();
+          expect('.open .dropdown-menu').not.toExist();
         });
 
         describe('when scrim is disabled', () => {
@@ -94,11 +93,11 @@ describe('Dropdowns', () => {
             subject::setProps({disableScrim: true});
 
             $('.dropdown-toggle').simulate('click');
-            expect('.dropdown-menu').toExist();
+            expect('.open .dropdown-menu').toExist();
             const evt = document.createEvent('HTMLEvents');
             evt.initEvent('click', true, true );
             document.documentElement.dispatchEvent(evt);
-            expect('.dropdown-menu').toExist();
+            expect('.open .dropdown-menu').toExist();
           });
         });
       });

--- a/library/spec/pivotal-ui-react/notification/notification_spec.js
+++ b/library/spec/pivotal-ui-react/notification/notification_spec.js
@@ -34,6 +34,8 @@ describe('Notification', function() {
           <NotificationItem href="my-fo-link">fo</NotificationItem>
           <NotificationItem href="my-fum-link">fum</NotificationItem>
         </Notifications>), root);
+
+      $('.dropdown-toggle').simulate('click');
     });
 
     it('passes through the className to the btn-group', function() {
@@ -85,7 +87,9 @@ describe('Notification', function() {
       expect('.dropdown-notifications-title .dropdown-notifications-badge').not.toExist();
     });
 
-    it('renders the no notification message', function() {
+    it('renders the no notification message on click', function() {
+      $('.dropdown-toggle').simulate('click');
+
       expect('.dropdown-menu .dropdown-notifications-none').toContainText('no notifications');
     });
   });
@@ -134,7 +138,9 @@ describe('Alert Notifications', function() {
       expect('.dropdown-notifications-title .dropdown-notifications-alert').toHaveClass('fa-exclamation-triangle');
     });
 
-    it('renders the children in a dropdown menu', function() {
+    it('renders the children in a dropdown menu on click', function() {
+      $('.dropdown-toggle').simulate('click');
+
       expect('.dropdown-menu a:eq(0)').toContainText('fee');
       expect('.dropdown-menu a:eq(0)').toHaveAttr('href', 'my-fee-link');
 
@@ -166,7 +172,9 @@ describe('Alert Notifications', function() {
       expect('.dropdown-notifications-title .dropdown-notifications-alert').not.toExist();
     });
 
-    it('renders the no notification message', function() {
+    it('renders the no notification message on click', function() {
+      $('.dropdown-toggle').simulate('click');
+
       expect('.dropdown-menu .dropdown-notifications-none').toContainText('no alerts');
     });
   });

--- a/library/src/pivotal-ui-react/dropdowns/dropdowns.js
+++ b/library/src/pivotal-ui-react/dropdowns/dropdowns.js
@@ -1,61 +1,113 @@
-var React = require('react');
+import React from 'react';
+import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import uniqueid from 'lodash.uniqueid';
+
+import mixin from 'pui-react-mixins';
+import Scrim from 'pui-react-mixins/mixins/scrim_mixin';
+
 require('pui-css-dropdowns');
 
 const types = React.PropTypes;
 
-var BsDropdown = require('react-bootstrap/lib/Dropdown');
+const DEFAULT_KIND = 'btn-default';
+const DEFAULT_TOGGLE = <span className="caret"/>;
 
-function defDropdown(props) {
-  return class extends React.Component {
-    static propTypes = {
-      border: types.bool,
-      bsStyle: types.any,
-      buttonClassName: types.string,
-      id: types.oneOfType([types.string, types.number]),
-      split: types.bool,
-      style: types.any,
-      title: types.node,
-      toggle: types.node
-    };
-
-    render = function render() {
-      const {border, buttonClassName, children, style, title, split, toggle, ...others} = this.props;
-      let {id} = others;
-      const {buttonClassName: defaultBtnClassName, bsStyle} = props;
-
-      const bsClass = bsStyle ? `btn-${bsStyle}` : null;
-      const btnClass = classnames(buttonClassName, defaultBtnClassName, 'btn', bsClass);
-      const borderClass = border ? 'dropdown-border' : null;
-      if (!id) {
-        id = uniqueid('dropdown');
-      }
-
-      let dropdownLabel, dropdownToggleContent;
-
-      if (split || toggle) {
-        dropdownLabel = (
-          <div className={classnames('dropdown-label', btnClass)}>{title}</div>
-        );
-        dropdownToggleContent = toggle;
-      } else {
-        dropdownToggleContent = title;
-      }
-
-      return (
-        <BsDropdown {...others} id={id}>
-          {dropdownLabel}
-          <BsDropdown.Toggle className={btnClass} noCaret={!!toggle} bsStyle={bsStyle} style={style}>
-            {dropdownToggleContent}
-          </BsDropdown.Toggle>
-          <BsDropdown.Menu className={borderClass}>
-            {children}
-          </BsDropdown.Menu>
-        </BsDropdown>
-      );
+class Dropdown extends mixin(React.Component).with(Scrim) {
+  constructor(props, context) {
+    super(props, context);
+    this.state = {
+      isOpen: false
     };
   }
+
+  static propTypes = {
+    buttonClassName: types.string,
+    disableScrim: types.bool,
+    id: types.oneOfType([types.string, types.number]),
+    split: types.bool,
+    style: types.any,
+    title: types.node,
+    toggle: types.node
+  };
+
+  static defaultProps = {
+    disableScrim: false
+  };
+
+  click = () => {
+    this.setState({isOpen: !this.state.isOpen});
+  };
+
+  scrimClick = () => {
+    this.setState({isOpen: false});
+  };
+
+  render() {
+    const {buttonClassName, children, className, id, kind, split, style, title, toggle} = this.props;
+    const {isOpen} = this.state;
+
+    let buttonKind, dropdownLabel, dropdownToggle, dropdownMenu, toggleNode;
+
+    buttonKind = kind ? `btn-${kind}` : DEFAULT_KIND;
+    toggleNode = toggle ? toggle : DEFAULT_TOGGLE;
+
+    const buttonStyleClasses = classnames('btn', buttonKind, buttonClassName);
+    dropdownLabel = split ? <div className={classnames('dropdown-label', buttonStyleClasses)}>{title}</div> : null;
+    dropdownToggle = (
+      <button id={id} style={style} onClick={this.click} className={classnames('dropdown-toggle', buttonStyleClasses)}>
+        {!split ? title : null}
+        {toggleNode}
+      </button>
+    );
+
+    dropdownMenu = isOpen ? <ul className="dropdown-menu">{children}</ul> : null;
+
+    const dropdownClasses = classnames('dropdown', 'btn-group', {open: isOpen}, {split: split}, className);
+    return (
+      <div className={dropdownClasses}>
+        {dropdownLabel}
+        {dropdownToggle}
+        {dropdownMenu}
+      </div>
+    );
+  };
+}
+
+class LinkDropdown extends Dropdown {
+  static defaultProps = {
+    kind: 'link'
+  };
+}
+
+class DefaultAltDropdown extends Dropdown {
+  static defaultProps = {
+    kind: 'default-alt'
+  };
+}
+
+class LowlightDropdown extends Dropdown {
+  static defaultProps = {
+    kind: 'lowlight'
+  };
+}
+
+class DangerDropdown extends Dropdown {
+  static defaultProps = {
+    kind: 'danger'
+  };
+}
+
+class HighlightDropdown extends Dropdown {
+  static defaultProps = {
+    kind: 'highlight'
+  };
+}
+
+class HighlightAltDropdown extends Dropdown {
+  static defaultProps = {
+    kind: 'highlight-alt'
+  };
 }
 
 class DropdownItem extends React.Component {
@@ -109,19 +161,12 @@ class DropdownItem extends React.Component {
 }
 
 module.exports = {
-  Dropdown: defDropdown({buttonClassName: 'btn-default'}),
-
-  DropdownItem: DropdownItem,
-
-  LinkDropdown: defDropdown({bsStyle: 'link'}),
-
-  DefaultAltDropdown: defDropdown({buttonClassName: 'btn-default-alt', bsStyle: null}),
-
-  LowlightDropdown: defDropdown({buttonClassName: 'btn-lowlight', bsStyle: null}),
-
-  DangerDropdown: defDropdown({bsStyle: 'danger'}),
-
-  HighlightDropdown: defDropdown({buttonClassName: 'btn-highlight', bsStyle: null}),
-
-  HighlightAltDropdown: defDropdown({buttonClassName: 'btn-highlight-alt', bsStyle: null})
+  Dropdown,
+  DropdownItem,
+  LinkDropdown,
+  DefaultAltDropdown,
+  HighlightAltDropdown,
+  HighlightDropdown,
+  DangerDropdown,
+  LowlightDropdown
 };

--- a/library/src/pivotal-ui-react/dropdowns/dropdowns.js
+++ b/library/src/pivotal-ui-react/dropdowns/dropdowns.js
@@ -47,7 +47,7 @@ class Dropdown extends mixin(React.Component).with(Scrim) {
     const {buttonClassName, children, className, id, kind, split, style, title, toggle} = this.props;
     const {isOpen} = this.state;
 
-    let buttonKind, dropdownLabel, dropdownToggle, dropdownMenu, toggleNode;
+    let buttonKind, dropdownLabel, dropdownToggle, toggleNode;
 
     buttonKind = kind ? `btn-${kind}` : DEFAULT_KIND;
     toggleNode = toggle ? toggle : DEFAULT_TOGGLE;
@@ -61,14 +61,12 @@ class Dropdown extends mixin(React.Component).with(Scrim) {
       </button>
     );
 
-    dropdownMenu = isOpen ? <ul className="dropdown-menu">{children}</ul> : null;
-
     const dropdownClasses = classnames('dropdown', 'btn-group', {open: isOpen}, {split: split}, className);
     return (
       <div className={dropdownClasses}>
         {dropdownLabel}
         {dropdownToggle}
-        {dropdownMenu}
+        <ul className="dropdown-menu">{children}</ul>
       </div>
     );
   };

--- a/library/src/pivotal-ui-react/dropdowns/dropdowns.js
+++ b/library/src/pivotal-ui-react/dropdowns/dropdowns.js
@@ -22,9 +22,11 @@ class Dropdown extends mixin(React.Component).with(Scrim) {
   }
 
   static propTypes = {
+    border: types.bool,
     buttonClassName: types.string,
     disableScrim: types.bool,
     id: types.oneOfType([types.string, types.number]),
+    pullRight: types.bool,
     split: types.bool,
     style: types.any,
     title: types.node,
@@ -44,7 +46,7 @@ class Dropdown extends mixin(React.Component).with(Scrim) {
   };
 
   render() {
-    const {buttonClassName, children, className, id, kind, split, style, title, toggle} = this.props;
+    const {border, buttonClassName, children, className, id, kind, pullRight, split, style, title, toggle} = this.props;
     const {isOpen} = this.state;
 
     let buttonKind, dropdownLabel, dropdownToggle, toggleNode;
@@ -62,11 +64,12 @@ class Dropdown extends mixin(React.Component).with(Scrim) {
     );
 
     const dropdownClasses = classnames('dropdown', 'btn-group', {open: isOpen}, {split: split}, className);
+    const dropdownMenuClasses = classnames('dropdown-menu', {'dropdown-border': border}, {'dropdown-menu-right': pullRight});
     return (
       <div className={dropdownClasses}>
         {dropdownLabel}
         {dropdownToggle}
-        <ul className="dropdown-menu">{children}</ul>
+        <ul className={dropdownMenuClasses}>{children}</ul>
       </div>
     );
   };

--- a/library/src/pivotal-ui/components/dropdowns/dropdowns.scss
+++ b/library/src/pivotal-ui/components/dropdowns/dropdowns.scss
@@ -1,10 +1,26 @@
 @import "../pui-variables";
 @import '../../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/mixins';
 
-
-
 .dropdown {
   display: inline-block;
+
+  &.split .caret {
+    margin-left: 0;
+  }
+
+  .caret {
+    margin-left: 3px;
+  }
+
+  &, &.open {
+    .dropdown-label.btn-danger, .dropdown-toggle.btn-danger {
+      border-color: transparent;
+
+      &:hover, &:active {
+        border-color: transparent;
+      }
+    }
+  }
 }
 
 .dropdown-menu {
@@ -33,7 +49,6 @@
     }
   }
 }
-
 
 .dropdown-notifications-none {
   width: 200px;

--- a/library/src/pivotal-ui/components/dropdowns/index.js
+++ b/library/src/pivotal-ui/components/dropdowns/index.js
@@ -1,4 +1,5 @@
 try {
+  require('pui-css-bootstrap');
   require('pui-css-buttons');
   require('pui-css-button-group');
   require('pui-css-links');

--- a/library/src/pivotal-ui/components/dropdowns/index.js
+++ b/library/src/pivotal-ui/components/dropdowns/index.js
@@ -1,5 +1,4 @@
 try {
-  require('pui-css-bootstrap');
   require('pui-css-buttons');
   require('pui-css-button-group');
   require('pui-css-links');

--- a/styleguide/docs/react/dropdowns.js
+++ b/styleguide/docs/react/dropdowns.js
@@ -86,10 +86,21 @@ If you want to separate your dropdown label from the toggle trigger, you can pas
 </DefaultAltDropdown>
 ```
 
+If you want a dropdown without a label, you can omit the `title` attribute.
+
+```react_example
+<DefaultAltDropdown toggle={<div style={{color: 'darkgoldenrod'}}>&#9733;</div>}>
+  <DropdownItem href="http://media.giphy.com/media/13py6c5BSnBkic/giphy.gif">Booyeah</DropdownItem>
+  <DropdownItem href="http://media.giphy.com/media/TlK63EQERmiAVzMEgO4/giphy.gif">Adorable</DropdownItem>
+  <DropdownItem href="http://media.giphy.com/media/13py6c5BSnBkic/giphy.gif">Booyeah</DropdownItem>
+  <DropdownItem href="http://media.giphy.com/media/TlK63EQERmiAVzMEgO4/giphy.gif">Adorable</DropdownItem>
+</DefaultAltDropdown>
+```
+
 If you want a custom toggle trigger, you can pass the `toggle` attribute.
 
 ```react_example
-<DefaultAltDropdown toggle={<div style={{color: 'darkgoldenrod'}}>O</div>} title='DropDown'>
+<DefaultAltDropdown split toggle={<div style={{color: 'darkgoldenrod'}}>&#9733;</div>} title='DropDown'>
   <DropdownItem href="http://media.giphy.com/media/13py6c5BSnBkic/giphy.gif">Booyeah</DropdownItem>
   <DropdownItem href="http://media.giphy.com/media/TlK63EQERmiAVzMEgO4/giphy.gif">Adorable</DropdownItem>
   <DropdownItem href="http://media.giphy.com/media/13py6c5BSnBkic/giphy.gif">Booyeah</DropdownItem>

--- a/styleguide/docs/react/dropdowns.js
+++ b/styleguide/docs/react/dropdowns.js
@@ -100,7 +100,7 @@ If you want a dropdown without a label, you can omit the `title` attribute.
 If you want a custom toggle trigger, you can pass the `toggle` attribute.
 
 ```react_example
-<DefaultAltDropdown split toggle={<div style={{color: 'darkgoldenrod'}}>&#9733;</div>} title='DropDown'>
+<DefaultAltDropdown toggle={<span style={{color: 'darkgoldenrod'}}>&#9733;</span>} title='DropDown'>
   <DropdownItem href="http://media.giphy.com/media/13py6c5BSnBkic/giphy.gif">Booyeah</DropdownItem>
   <DropdownItem href="http://media.giphy.com/media/TlK63EQERmiAVzMEgO4/giphy.gif">Adorable</DropdownItem>
   <DropdownItem href="http://media.giphy.com/media/13py6c5BSnBkic/giphy.gif">Booyeah</DropdownItem>


### PR DESCRIPTION
[#116913731]

BREAKING CHANGE: split prop must be passed in to split the dropdown
label and toggle. Previously, providing a toggle would automatically
split the label and toggle.

Signed-off-by: Elena Sharma <esharma@pivotal.io>