### PR TITLE
feat(DropdownItem): Pass additional props if DropdownItem has an href

### DIFF
--- a/library/spec/pivotal-ui-react/dropdown/dropdown-item_spec.js
+++ b/library/spec/pivotal-ui-react/dropdown/dropdown-item_spec.js
@@ -42,11 +42,28 @@ describe('DropdownItem', () => {
   });
 
   describe('href', () => {
-    it('passes through id to the anchor', () => {
+    it('passes through id and href to the anchor', () => {
       ReactDOM.render(
         <DropdownItem href='test' {...props}>Item</DropdownItem>,
         root);
       expect('#root li a#test-item-id').toExist();
+      expect('#root li a#test-item-id').toHaveAttr('href', 'test');
+    });
+
+    describe('target', () => {
+      it('passes through target to the anchor when provided', () => {
+        ReactDOM.render(
+          <DropdownItem href='test' target="_blank" {...props}>Item</DropdownItem>,
+          root);
+        expect('#root li a#test-item-id').toHaveAttr('target', '_blank');
+      });
+
+      it('does not pass through target to the anchor when provided', () => {
+        ReactDOM.render(
+          <DropdownItem href='test' {...props}>Item</DropdownItem>,
+          root);
+        expect('#root li a#test-item-id').not.toHaveAttr('target');
+      });
     });
   });
 

--- a/library/src/pivotal-ui-react/dropdowns/dropdowns.js
+++ b/library/src/pivotal-ui-react/dropdowns/dropdowns.js
@@ -121,7 +121,8 @@ class DropdownItem extends React.Component {
     divider: types.bool,
     disabled: types.bool,
     eventKey: types.string,
-    onSelect: types.func
+    onSelect: types.func,
+    target: types.string
   };
 
   handleClick = (event) => {
@@ -139,14 +140,14 @@ class DropdownItem extends React.Component {
   };
 
   render() {
-    const {children, className, style, href, id, header, divider, disabled} = this.props;
+    const {children, className, style, href, header, divider, disabled, ...anchorProps} = this.props;
 
     if (header) return (<li role="heading" className="dropdown-header">{children}</li>);
     if (divider) return (<li role="separator" className="divider"/>);
 
     let anchor;
     if (href) {
-      anchor = <a {...{href, id}} disabled={disabled} onClick={this.handleClick}>{children}</a>;
+      anchor = <a {...{href, disabled, ...anchorProps}} onClick={this.handleClick}>{children}</a>;
     } else {
       anchor = children;
     }


### PR DESCRIPTION
We'd like to pass through additional props, such as `target`, to the anchor tag inside of a DropdownItem.