### PR TITLE
fix(table): do not allow the data property to be added to the table element itself

### DIFF
--- a/library/spec/pivotal-ui-react/table/table_spec.js
+++ b/library/spec/pivotal-ui-react/table/table_spec.js
@@ -448,6 +448,36 @@ describe('Table', function() {
     expect('tbody tr:nth-of-type(2) > td:eq(2)').toContainText(2);
     expect('tbody tr:nth-of-type(3) > td:eq(2)').toContainText(3);
   });
+
+  it('does not render the data as an attribute', () => {
+    const columns = [
+      {
+        attribute: 'title',
+        displayName: 'Title',
+        sortable: true
+      },
+      {
+        attribute: 'bar',
+        displayName: 'Bar',
+        sortable: true
+      },
+      {
+        attribute: 'theDefault',
+        displayName: 'DefaultSort',
+        sortable: true
+      }
+    ];
+
+    const data = [
+      { title: 'foo', bar: 'a', theDefault: 3},
+      { title: 'sup', bar: 'c', theDefault: 2},
+      { title: 'yee', bar: 'b', theDefault: 1}
+    ];
+
+    ReactDOM.render(<Table columns={columns} data={data}/>, root);
+
+    expect('table').not.toHaveAttr('data');
+  });
 });
 
 describe('TableHeader', function() {

--- a/library/src/pivotal-ui-react/table/table.js
+++ b/library/src/pivotal-ui-react/table/table.js
@@ -115,13 +115,13 @@ export class Table extends React.Component {
 
   render() {
     const {sortColumn} = this.state;
-    const {data} = this.props;
-    const props = mergeProps(this.props, {className: ['table', 'table-sortable', 'table-data']});
+    let {data, ...props} = this.props;
+    props = mergeProps(props, {className: ['table', 'table-sortable', 'table-data']});
 
     const rows = (sortColumn === -1) ? this.rows(data) : this.sortedRows();
 
     return (
-      <table {...props} >
+      <table {...props}>
         <thead>
           <tr>{this.renderHeaders()}</tr>
         </thead>


### PR DESCRIPTION
The table react component seems to add the data props to the table element which results in the table strings being written as data="Object [object] Object [object] Object [object]"

This removes the prop from the table.