### PR TITLE
feature(progress-bars): improve default style

### DIFF
--- a/library/src/pivotal-ui/components/progress-bars/README.md
+++ b/library/src/pivotal-ui/components/progress-bars/README.md
@@ -1,12 +1,9 @@
 ```html
 <div class="progress">
-  <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="9" class="progress-bar" role="progressbar" style="width: 9%;">
-    <div class="label">
-      9%
-    </div>
-  </div>
+  <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="60" class="progress-bar" role="progressbar" style="width: 60%;"></div>
 </div>
-<p>
-  9 MB of 100 MB Used
-</p>
+<div class="mts">
+  <div class="type-sm" style="float:left">60 MB / 100 MB</div>
+  <div class="type-sm" style="float:right">60%</div>
+</div>
 ```

--- a/library/src/pivotal-ui/components/progress-bars/progress-bars.scss
+++ b/library/src/pivotal-ui/components/progress-bars/progress-bars.scss
@@ -1,16 +1,20 @@
 @import "../pui-variables";
 
 .progress {
-  background-color: $shadow-3;
+  background-color: $navy-9;
 
   overflow: hidden;
+
+  min-height: 10px;
 }
 
 .progress-bar {
   -webkit-transition: width .6s ease;
   transition: width .6s ease;
 
-  background: $gray-5;
+  background: $blue-3;
+
+  min-height: 10px;
 
   .label {
     margin-left: 7px;
@@ -28,8 +32,4 @@
   color: $text-color;
   min-width: 3%;
   background: transparent;
-}
-
-.progress-bar[aria-valuenow^="9"]:not([aria-valuenow="9"]), .progress-bar[aria-valuenow="100"] {
-  background: $red-3;
 }

--- a/styleguide/docs/css/progress-bars.scss
+++ b/styleguide/docs/css/progress-bars.scss
@@ -16,61 +16,48 @@ npm install pui-css-progress-bars --save
 
 This section contains static progress bar styles.
 
+Default styles.
 
 ```html_example_table
 <div class="progress">
-  <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar" role="progressbar" style="width: 0%;">
-    <div class="label">
-      0%
-    </div>
-  </div>
+  <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar" role="progressbar" style="width: 0%;"></div>
 </div>
-<p>
-  0 MB of 100 MB Used
-</p>
+<div class="mts">
+  <div class="type-sm" style="float:left">0 MB / 100 MB</div>
+  <div class="type-sm" style="float:right">0%</div>
+</div>
 
 <div class="progress">
-  <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="3" class="progress-bar" role="progressbar" style="width: 3%;">
-    <div class="label">
-      3%
-    </div>
-  </div>
+  <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="60" class="progress-bar" role="progressbar" style="width: 60%;"></div>
 </div>
-<p>
-  3 MB of 100 MB Used
-</p>
+<div class="mts">
+  <div class="type-sm" style="float:left">60 MB / 100 MB</div>
+  <div class="type-sm" style="float:right">60%</div>
+</div>
+```
 
-<div class="progress">
-  <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="9" class="progress-bar" role="progressbar" style="width: 9%;">
-    <div class="label">
-      9%
-    </div>
-  </div>
-</div>
-<p>
-  9 MB of 100 MB Used
-</p>
+Customize the progress bar background color.
 
+```html_example_table
 <div class="progress">
-  <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="60" class="progress-bar" role="progressbar" style="width: 60%;">
-    <div class="label">
-      60%
-    </div>
-  </div>
+  <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="90" class="progress-bar bg-error-3" role="progressbar" style="width: 90%;"></div>
 </div>
-<p>
-  60 MB of 100 MB Used
-</p>
+<div class="mts">
+  <div class="type-sm" style="float:left">90 MB / 100 MB</div>
+  <div class="type-sm" style="float:right">90%</div>
+</div>
+```
 
-<div class="progress">
-  <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="90" class="progress-bar" role="progressbar" style="width: 90%;">
-    <div class="label">
-      90%
-    </div>
+Customize the progress bar with a custom label, larger height, and background color.
+
+```html_example_table
+<div class="progress bg-shadow-3">
+  <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="60" class="progress-bar bg-neutral-5" role="progressbar" style="width: 60%;">
+    <div class="label">60%</div>
   </div>
 </div>
 <p>
-  90 MB of 100 MB Used
+  60 MB / 100 MB
 </p>
 ```
 */


### PR DESCRIPTION
- no longer set background color to red when the progress bar reaches 90%
- min-height of progress bar is 10px
- default color of progress bar is $navy-9