### PR TITLE
chore(documentation): align shadow chips

### DIFF
--- a/styleguide/docs/css/colors.scss
+++ b/styleguide/docs/css/colors.scss
@@ -454,8 +454,8 @@ title: Shadows & Glows
 name: color_shadows_glows
 parent: color
 ---
-<div class="contrast-bar">
-  <div class="color-chip-row" style="position: relative; top: 65px; margin-bottom: 0;">
+<div class="contrast-bar" style="background-image: linear-gradient(-180deg, #788E9A 0%, #243641 37%, #788E9A 38%, #243641 100%);">
+  <div class="color-chip-row">
       <div class="chip">
         <div class="chip-color bg-shadow-1"></div>
         <div class="chip-color-name">$shadow-1</div>
@@ -492,8 +492,6 @@ parent: color
         <div class="chip-color bg-glow-5"></div>
         <div class="chip-color-name">$glow-5</div>
       </div>
-      <div class="chip"></div>
-      <div class="chip"></div>
   </div>
 </div>
 */


### PR DESCRIPTION
@pivotal-plech and I worked to remove an inline style on the shadow chips in the color documentation to improve the alignment of this design element. We also changed the background color of the containing div to better illustrate how to use this element.

GitHub Issue #412