### PR TITLE
[#135361221] fix weird column resize

### DIFF
--- a/library/src/pivotal-ui/components/tables/tables.scss
+++ b/library/src/pivotal-ui/components/tables/tables.scss
@@ -13,11 +13,6 @@
   .td {
     padding: 20px $whitespace-l;
   }
-  .tbody {
-
-    .tr:nth-child(odd) {
-    }
-  }
 }
 
 .table-data {
@@ -138,6 +133,11 @@
       -moz-transition: background-color 300ms ease-out;
       transition: background-color 300ms ease-out;
     }
+  }
+
+  .svgicon {
+    position: absolute;
+    margin-top: -5px;
   }
 
   .icon-arrow_drop_up, .icon-arrow_drop_down {


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1126018/stories/135361221

Not 100% stoked about using position absolute but with any relative positioning I can think of the table header would get moved (since the columns don't have a fixed width). Open to better ideas!

Another thought I had was each column could have that space defined (fixed width) but either empty/not empty. This PRed solution is quite a bit simpler and more intuitive, which is why I went this direction.

Again, open to other ideas.