### PR TITLE
Feat(Buttons): Add support for button icons

### DIFF
--- a/library/spec/pivotal-ui-react/buttons/button_spec.js
+++ b/library/spec/pivotal-ui-react/buttons/button_spec.js
@@ -76,7 +76,6 @@ describe('UIButton', function() {
       });
     });
 
-
     describe('when options that add class names are given', function() {
       beforeEach(function() {
         renderButton({
@@ -166,4 +165,19 @@ describe('UIButton', function() {
       });
     });
   });
+
+  describe('button with icons', () => {
+    const {Icon} = require('../../../src/pivotal-ui-react/iconography/iconography');
+    const {DefaultButton} = require('../../../src/pivotal-ui-react/buttons/buttons');
+
+    it('renders with an icon if an icon node is passed through props', () => {
+      ReactDOM.render(<DefaultButton icon={<Icon src="add" />}>Click here</DefaultButton>, root);
+      expect('#root button .svgicon').toExist();
+    });
+
+    it('renders with an icon if it is a link', () => {
+      ReactDOM.render(<DefaultButton href="whatever" icon={<Icon src="add" />}>Click here</DefaultButton>, root);
+      expect('#root a.button .svgicon').toExist();
+    });
+  })
 });

--- a/library/src/pivotal-ui-react/buttons/buttons.js
+++ b/library/src/pivotal-ui-react/buttons/buttons.js
@@ -2,7 +2,7 @@ var React = require('react');
 import {mergeProps} from 'pui-react-helpers';
 require('pui-css-buttons');
 
-class UIButton extends React.Component{
+class UIButton extends React.Component {
   static propTypes = {
     alt: React.PropTypes.bool,
     flat: React.PropTypes.bool,
@@ -14,7 +14,8 @@ class UIButton extends React.Component{
       'brand'
     ]),
     large: React.PropTypes.bool,
-    small: React.PropTypes.bool
+    small: React.PropTypes.bool,
+    icon: React.PropTypes.node
   };
 
   static defaultProps = {
@@ -22,25 +23,25 @@ class UIButton extends React.Component{
   };
 
   render() {
-    const {alt, flat, large, small, kind, children, ...others} = this.props;
+    const {alt, flat, large, small, kind, children, icon, ...others} = this.props;
 
-    let defaultProps = {
+    const defaultProps = {
       className: [
-          {
-            'button': this.props.href,
-            [`btn-${kind}-alt`]: alt,
-            [`btn-${kind}-flat`]: flat,
-            [`btn-${kind}`]: !alt && !flat,
-            'btn-lg': large,
-            'btn-sm': small
-          }
+        {
+          'button': this.props.href,
+          [`btn-${kind}-alt`]: alt,
+          [`btn-${kind}-flat`]: flat,
+          [`btn-${kind}`]: !alt && !flat,
+          'btn-lg': large,
+          'btn-sm': small
+        }
       ]
     };
-    let props = mergeProps(others, defaultProps);
+    const props = mergeProps(others, defaultProps);
 
     return this.props.href ?
-      <a {...props}>{children}</a> :
-      <button {...props}>{children}</button>;
+      <a {...props}>{icon} {children}</a> :
+      <button {...props}>{icon} {children}</button>;
   }
 }
 
@@ -62,12 +63,8 @@ function defButton(propOverrides) {
 
 module.exports = {
   UIButton,
-
   DefaultButton: defButton({kind: 'default'}),
-
   DangerButton: defButton({kind: 'danger'}),
-
   PrimaryButton: defButton({kind: 'primary'}),
-
   BrandButton: defButton({kind: 'brand'})
 };

--- a/library/src/pivotal-ui/components/buttons/buttons.scss
+++ b/library/src/pivotal-ui/components/buttons/buttons.scss
@@ -37,9 +37,9 @@ input[type="button"] {
     padding: 2px;
     fill: $btn-default-color;
   }
-  .spinner,
-  .spinner-md,
-  .spinner-sm {
+  .icon-spinner,
+  .icon-spinner-md,
+  .icon-spinner-sm {
     margin-right: 2px;
     padding: 2px;
   }
@@ -139,9 +139,9 @@ button.btn-default,
 input[type="submit"].btn-default,
 input[type="reset"].btn-default,
 input[type="button"].btn-default {
-  .spinner,
-  .spinner-md,
-  .spinner-sm {
+  .icon-spinner,
+  .icon-spinner-md,
+  .icon-spinner-sm {
     .ring {
       stroke: $btn-light;
     }
@@ -206,9 +206,9 @@ button.btn-default-alt,
 input[type="submit"].btn-default-alt,
 input[type="reset"].btn-default-alt,
 input[type="button"].btn-default-alt {
-  .spinner,
-  .spinner-md,
-  .spinner-sm {
+  .icon-spinner,
+  .icon-spinner-md,
+  .icon-spinner-sm {
     .ring {
       stroke: $btn-default-color;
     }
@@ -272,9 +272,9 @@ button.btn-default-alt-wh,
 input[type="submit"].btn-default-alt-wh,
 input[type="reset"].btn-default-alt-wh,
 input[type="button"].btn-default-alt-wh {
-  .spinner,
-  .spinner-md,
-  .spinner-sm {
+  .icon-spinner,
+  .icon-spinner-md,
+  .icon-spinner-sm {
     .ring {
       stroke: $btn-light;
     }
@@ -330,9 +330,9 @@ button.btn-primary,
 input[type="submit"].btn-primary,
 input[type="reset"].btn-primary,
 input[type="button"].btn-primary {
-  .spinner,
-  .spinner-md,
-  .spinner-sm {
+  .icon-spinner,
+  .icon-spinner-md,
+  .icon-spinner-sm {
     .ring {
       stroke: $btn-light;
     }
@@ -413,9 +413,9 @@ button.btn-primary-alt,
 input[type="submit"].btn-primary-alt,
 input[type="reset"].btn-primary-alt,
 input[type="button"].btn-primary-alt {
-  .spinner,
-  .spinner-md,
-  .spinner-sm {
+  .icon-spinner,
+  .icon-spinner-md,
+  .icon-spinner-sm {
     .ring {
       stroke: $btn-primary-color;
     }
@@ -471,9 +471,9 @@ button.btn-danger,
 input[type="submit"].btn-danger,
 input[type="reset"].btn-danger,
 input[type="button"].btn-danger {
-  .spinner,
-  .spinner-md,
-  .spinner-sm {
+  .icon-spinner,
+  .icon-spinner-md,
+  .icon-spinner-sm {
     .ring {
       stroke: $btn-light;
     }
@@ -551,9 +551,9 @@ button.btn-danger-alt,
 input[type="submit"].btn-danger-alt,
 input[type="reset"].btn-danger-alt,
 input[type="button"].btn-danger-alt {
-  .spinner,
-  .spinner-md,
-  .spinner-sm {
+  .icon-spinner,
+  .icon-spinner-md,
+  .icon-spinner-sm {
     .ring {
       stroke: $btn-danger-color;
     }
@@ -609,9 +609,9 @@ button.btn-brand,
 input[type="submit"].btn-brand,
 input[type="reset"].btn-brand,
 input[type="button"].btn-brand {
-  .spinner,
-  .spinner-md,
-  .spinner-sm {
+  .icon-spinner,
+  .icon-spinner-md,
+  .icon-spinner-sm {
     .ring {
       stroke: $btn-light;
     }
@@ -692,9 +692,9 @@ button.btn-brand-alt,
 input[type="submit"].btn-brand-alt,
 input[type="reset"].btn-brand-alt,
 input[type="button"].btn-brand-alt {
-  .spinner,
-  .spinner-md,
-  .spinner-sm {
+  .icon-spinner,
+  .icon-spinner-md,
+  .icon-spinner-sm {
     .ring {
       stroke: $btn-brand-color;
     }

--- a/styleguide/docs/react/buttons.js
+++ b/styleguide/docs/react/buttons.js
@@ -16,6 +16,7 @@ Import the subcomponents:
 
 ```
 import {DefaultButton, PrimaryButton, DangerButton, BrandButton} from 'pui-react-buttons';
+import {Icon} from 'pui-react-iconography';
 ```
 
 Buttons use the button tag by default. If you'd like a link rather than a button, simply add an `href` attribute.
@@ -80,6 +81,16 @@ To make a button large, set the `large` property to true, to make it small, set 
 
 <PrimaryButton small>
   Small Button
+</PrimaryButton>
+```
+
+## Icons
+
+Buttons can have icons by specifying the `icon` prop and giving it a node:
+
+```react_example_table
+<PrimaryButton icon={<Icon src="add"/>}>
+  Icon button
 </PrimaryButton>
 ```
 */


### PR DESCRIPTION
Current API:

```
<DangerButton icon={<Icon src="spinner"/>}>
      Link
</DangerButton>
```

Waiting on the **8pt grid story to be finished** before we style (and merge) this.

![screen shot 2016-12-20 at 10 18 05 am](https://cloud.githubusercontent.com/assets/3584893/21362930/3f566cfa-c69f-11e6-91ae-8b24fcb8fea8.png)

Also, note that if a user provides an icon with `verticalAlign="baseline"` it'll totally wreck the styling of the icon within the button. We could:

- Ignore their verticalAlign setting inside the `Button` component (basically overwrite it)
- More styling!