### PR TITLE
feat(Flexbox Grid): Begin work on flexbox grid (documentation lacking)

### DIFF
--- a/library/src/pivotal-ui/components/flexbox-grid/README.md
+++ b/library/src/pivotal-ui/components/flexbox-grid/README.md
@@ -1,0 +1,13 @@
+```html
+<div className='grid'>
+  <div className='col'>
+    Column
+  </div>
+  <div className='col'>
+    Column
+  </div>
+  <div className='col'>
+    Column
+  </div>
+</div>
+```

--- a/library/src/pivotal-ui/components/flexbox-grid/flexbox-grids.scss
+++ b/library/src/pivotal-ui/components/flexbox-grid/flexbox-grids.scss
@@ -1,0 +1,62 @@
+@import "../pui-variables";
+
+$base-unit: 8px;
+
+.grid {
+  box-sizing: border-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: -webkit-box;
+  display: flex;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  -webkit-box-flex: 0;
+  flex: 0 1 auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+
+  margin: 0 0 $base-unit*2 0;
+
+  &.grid-nogutter {
+    margin: 0;
+    & > .col {
+      padding: 0;
+    }
+  }
+
+  & > .col {
+    &:first-child {
+      padding-left: 0;
+    }
+    &:last-child {
+      padding-right: 0;
+    }
+  }
+}
+
+.col {
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  flex-grow: 1;
+  -ms-flex-preferred-size: 0;
+  -webkit-flex-basis: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  padding: 0 $base-unit 0 $base-unit;
+}
+
+// TODO: remove me
+.red {
+  background-color: red;
+}

--- a/library/src/pivotal-ui/components/flexbox-grid/index.js
+++ b/library/src/pivotal-ui/components/flexbox-grid/index.js
@@ -1,0 +1,4 @@
+try {
+  require('./flexbox-grids.css');
+} catch(e) {
+}

--- a/library/src/pivotal-ui/components/flexbox-grid/package.json
+++ b/library/src/pivotal-ui/components/flexbox-grid/package.json
@@ -1,0 +1,7 @@
+{
+  "homepage": "http://styleguide.pivotal.io/",
+  "dependencies": {
+    "pui-css-bootstrap": "^7.3.1"
+  },
+  "version": "7.3.1"
+}

--- a/styleguide/docs/css/flexbox-grids.scss
+++ b/styleguide/docs/css/flexbox-grids.scss
@@ -1,0 +1,17 @@
+/*doc
+---
+title: Flexbox Grid
+name: flexbox_grid
+categories:
+ - css_components_forms
+ - css_all
+---
+
+<code class="pam">
+<img src="/styleguide/download.svg" width="16" height="16"/>
+npm install pui-css-flexbox-grids --save
+</code>
+
+TODO: Documentation goes here
+
+*/


### PR DESCRIPTION
So, I'm not sure on several things, including what to name this (the `grid` folder and `pui-css-grids` package seem to be taken, although they internally use `col` and `row` instead). I'm also unsure what the documentation is exactly supposed to look like. I've started a very, very initial implementation that perhaps we can pick up once people are back?

Here is the `sandbox.js` I'm working with:

```
import React from 'react'
import '../../library/src/pivotal-ui/components/buttons'

module.exports = () => (
  <div style={{width: '100%'}}>
    <div className='grid'>
      <div className='col'>
        <div className="red">Column</div>
      </div>
      <div className='col'>
        <div className="red">Column</div>
      </div>
      <div className='col'>
        <div className="red">Column</div>
      </div>
    </div>

    <div className='grid grid-nogutter'>
      <div className='col'>
        <div className="red">Column</div>
      </div>
      <div className='col'>
        <div className="red">Column</div>
      </div>
      <div className='col'>
        <div className="red">Column</div>
      </div>
    </div>
  </div>
)
```