### PR TITLE
 do not make direct calls to document

### DIFF
--- a/library/spec/pivotal-ui-react/mixins/scrim_mixin_spec.js
+++ b/library/spec/pivotal-ui-react/mixins/scrim_mixin_spec.js
@@ -1,0 +1,24 @@
+import '../spec_helper';
+import ScrimMixin from '../../../src/pivotal-ui-react/mixins/mixins/scrim_mixin';
+import mixin from '../../../src/pivotal-ui-react/mixins/mixins';
+
+describe('ScrimMixin', () => {
+  let Component;
+
+  beforeEach(() => {
+    class Klass extends mixin(React.Component).with(ScrimMixin) {
+      render() {
+        return <div className="component"/>;
+      }
+    }
+    Component = Klass;
+  });
+
+  describe('when there is no document', () => {
+    it('does not throw an exception', () => {
+      expect(() => {
+        ReactDOM.render(<Component getDocument={() => undefined}/>, root);
+      }).not.toThrow()
+    });
+  });
+});

--- a/library/spec/pivotal-ui-react/modals/modals_spec.js
+++ b/library/spec/pivotal-ui-react/modals/modals_spec.js
@@ -283,4 +283,12 @@ describe('BaseModal', function() {
     );
     expect('.modal-dialog').toHaveClass('some-class-name');
   });
+
+  describe('when there is no document', () => {
+    it('does not throw an exception when rendered', () => {
+      expect(() => {
+        ReactDOM.render(<BaseModal show id="mr-modal" title="hey mr modal" getDocument={() => {}}/>, root);
+      }).not.toThrow();
+    });
+  });
 });

--- a/library/src/pivotal-ui-react/mixins/mixins/scrim_mixin.js
+++ b/library/src/pivotal-ui-react/mixins/mixins/scrim_mixin.js
@@ -14,7 +14,7 @@ export default ParentClass => {
   return class Scrim extends ParentClass {
     static propTypes = {
       disableScrim: types.bool
-    }
+    };
 
     constructor(props, context) {
       super(props, context);
@@ -26,12 +26,14 @@ export default ParentClass => {
 
     componentDidMount(...args) {
       if (super.componentDidMount) super.componentDidMount(...args);
-      document.documentElement.addEventListener('click', privates.get(this));
+      const document = this.props.getDocument ? this.props.getDocument() : global.document;
+      if (typeof document === 'object') document.documentElement.addEventListener('click', privates.get(this));
     }
 
     componentWillUnmount(...args) {
       if (super.componentWillUnmount) super.componentWillUnmount(...args);
-      document.documentElement.removeEventListener('click', privates.get(this));
+      const document = this.props.getDocument ? this.props.getDocument() : global.document;
+      if (typeof document === 'object') document.documentElement.removeEventListener('click', privates.get(this));
     }
-  };
+  }
 };

--- a/library/src/pivotal-ui-react/modals/modals.js
+++ b/library/src/pivotal-ui-react/modals/modals.js
@@ -9,13 +9,17 @@ const types = React.PropTypes;
 const ESC_KEY = 27;
 const privates = new WeakMap();
 
-const bodyNotAllowedToScroll = () => {
+function bodyNotAllowedToScroll(document)  {
+  if (typeof document !== 'object') return;
   const body = document.getElementsByTagName('body')[0];
   if(!body.classList.contains('pui-no-scroll')) {
     body.classList.add('pui-no-scroll');
   }
-};
-const bodyIsAllowedToScroll = () => document.getElementsByTagName('body')[0].classList.remove('pui-no-scroll');
+}
+
+function bodyIsAllowedToScroll(document) {
+  if (typeof document === 'object') document.getElementsByTagName('body')[0].classList.remove('pui-no-scroll');
+}
 
 export class BaseModal extends mixin(React.Component).with(Animation) {
   static propTypes = {
@@ -27,15 +31,16 @@ export class BaseModal extends mixin(React.Component).with(Animation) {
     onExited: types.func,
     onHide: types.func,
     show: types.bool,
-    title: types.node
+    title: types.node,
+    getDocument: types.func
   }
 
   static defaultProps = {
     animation: true,
     keyboard: true,
-    onHide: () => {
-    }
-  }
+    onHide: () => {},
+    getDocument: () => global.document
+  };
 
   static ANIMATION_TIME = 300;
   static ESC_KEY = ESC_KEY;
@@ -43,8 +48,8 @@ export class BaseModal extends mixin(React.Component).with(Animation) {
   constructor(props, context) {
     super(props, context);
     privates.set(this, {fractionShown: 0});
-
-    this.props.show ? bodyNotAllowedToScroll() : bodyIsAllowedToScroll();
+    const document = this.props.getDocument();
+    this.props.show ? bodyNotAllowedToScroll(document) : bodyIsAllowedToScroll(document);
   }
 
   modalClicked = e => {
@@ -60,12 +65,15 @@ export class BaseModal extends mixin(React.Component).with(Animation) {
   }
 
   componentDidMount() {
-    document.addEventListener('keydown', this.onKeyDown);
+    var document = this.props.getDocument();
+    if (typeof document === 'object') document.addEventListener('keydown', this.onKeyDown);
   }
 
   componentWillUnmount() {
+    var document = this.props.getDocument();
+    if (typeof document !== 'object') return;
     document.removeEventListener('keydown', this.onKeyDown);
-    bodyIsAllowedToScroll();
+    bodyIsAllowedToScroll(document);
   }
 
   focus = () => setTimeout(() => {
@@ -78,12 +86,13 @@ export class BaseModal extends mixin(React.Component).with(Animation) {
       size,
       children,
       dialogClassName,
-      keyboard: __ignore,
+      keyboard: __ignore1,
       onEntered,
       onExited,
       onHide,
       show,
       title,
+      getDocument: __ignore2,
       ...modalProps
     } = this.props;
     this.props.show ? bodyNotAllowedToScroll() : bodyIsAllowedToScroll();


### PR DESCRIPTION
Fix(Modals, Scrim): do not make direct calls to document

- dependency inject the document function for testability
- works without a document so the component can be server rendered.

Signed-off-by: Weyman Fung <wfung@pivotal.io>