### PR TITLE
Fixes(copy-to-clipboard): Fixes calls to window and document

### DIFF
--- a/library/spec/pivotal-ui-react/copy-to-clipboard/copy-to-clipboard_spec.js
+++ b/library/spec/pivotal-ui-react/copy-to-clipboard/copy-to-clipboard_spec.js
@@ -3,14 +3,19 @@ import ReactTestUtils from 'react-addons-test-utils'
 import {CopyToClipboard, CopyToClipboardButton} from '../../../src/pivotal-ui-react/copy-to-clipboard/copy-to-clipboard'
 
 describe('CopyToClipboard', () => {
+  function render(Component, props) {
+    return ReactTestUtils.renderIntoDocument(<Component {...props}/>)
+  }
+
   const text = 'some copy text'
-  let onClick, window, document, range, selection;
+  let onClick, getWindow, window, document, range, selection;
   beforeEach(() => {
     onClick = jasmine.createSpy('onClick')
 
     range = jasmine.createSpyObj('range', ['selectNode']);
     selection = jasmine.createSpyObj('selection', ['removeAllRanges', 'addRange']);
     window = jasmine.createSpyObj('window', ['getSelection']);
+    getWindow = jasmine.createSpy('getWindow').and.returnValue(window);
     document = jasmine.createSpyObj('document', ['createRange', 'execCommand']);
 
     document.createRange.and.returnValue(range);
@@ -19,18 +24,14 @@ describe('CopyToClipboard', () => {
   })
 
   describe('CopyToClipboard (basic)', () => {
-    const renderComponent = (props) => {
-      return ReactTestUtils.renderIntoDocument(<CopyToClipboard copyWindow={window} {...props}/>)
-    }
-
     it('renders the text', () => {
-      const result = renderComponent({text, onClick, className: 'test-class', id: 'test-id', style: {opacity: '0.5'}})
+      const result = render(CopyToClipboard, {text, onClick, className: 'test-class', id: 'test-id', style: {opacity: '0.5'}})
       const component = ReactTestUtils.findRenderedDOMComponentWithClass(result, 'sr-only')
       expect(component.textContent).toContain(text)
     })
 
     it('propagates attributes', () => {
-      const result = renderComponent({text, onClick, className: 'test-class', id: 'test-id', style: {opacity: '0.5'}})
+      const result = render(CopyToClipboard, {text, onClick, className: 'test-class', id: 'test-id', style: {opacity: '0.5'}})
       const component = ReactTestUtils.findRenderedDOMComponentWithClass(result, 'copy-to-clipboard')
 
       expect(component.className).toContain('test-class')
@@ -39,7 +40,7 @@ describe('CopyToClipboard', () => {
     })
 
     it('click copies text to clipboard and calls provided callback', () => {
-      const result = renderComponent({text, onClick, className: 'test-class', id: 'test-id', style: {opacity: '0.5'}})
+      const result = render(CopyToClipboard, {getWindow, text, onClick, className: 'test-class', id: 'test-id', style: {opacity: '0.5'}})
       const component = ReactTestUtils.findRenderedDOMComponentWithClass(result, 'copy-to-clipboard')
 
       ReactTestUtils.Simulate.click(component)
@@ -51,12 +52,8 @@ describe('CopyToClipboard', () => {
   })
 
   describe('CopyToClipboardButton', () => {
-    const renderComponent = (props) => {
-      return ReactTestUtils.renderIntoDocument(<CopyToClipboardButton copyWindow={window} {...props}/>)
-    }
-
     it('propagates attributes', () => {
-      const result = renderComponent({text, onClick, className: 'test-class', id: 'test-id', style: {opacity: '0.5'}})
+      const result = render(CopyToClipboardButton, {text, onClick, className: 'test-class', id: 'test-id', style: {opacity: '0.5'}})
       const component = ReactTestUtils.findRenderedDOMComponentWithClass(result, 'copy-to-clipboard')
 
       expect(component.className).toContain('test-class')
@@ -66,7 +63,7 @@ describe('CopyToClipboard', () => {
 
     describe('clicking on the button', () => {
       it('renders a tooltip that says "Copied"', () => {
-        const result = renderComponent({text, onClick, className: 'test-class', id: 'test-id', style: {opacity: '0.5'}})
+        const result = render(CopyToClipboardButton, {getWindow, text, onClick, className: 'test-class', id: 'test-id', style: {opacity: '0.5'}})
         const component = ReactTestUtils.findRenderedDOMComponentWithClass(result, 'clipboard-button')
         const tooltipContainer = ReactTestUtils.findRenderedDOMComponentWithClass(result, 'tooltip-container')
         const tooltip = ReactTestUtils.findRenderedDOMComponentWithClass(result, 'tooltip-content')
@@ -79,7 +76,7 @@ describe('CopyToClipboard', () => {
       })
 
       it('hides tooltip after 1 seconds', () => {
-        const result = renderComponent({text, onClick, className: 'test-class', id: 'test-id', style: {opacity: '0.5'}})
+        const result = render(CopyToClipboardButton, {getWindow, text, onClick, className: 'test-class', id: 'test-id', style: {opacity: '0.5'}})
         const component = ReactTestUtils.findRenderedDOMComponentWithClass(result, 'copy-to-clipboard')
         const tooltipContainer = ReactTestUtils.findRenderedDOMComponentWithClass(result, 'tooltip-container')
 
@@ -90,7 +87,7 @@ describe('CopyToClipboard', () => {
       })
 
       it('copies the text to the clipboard', () => {
-        const result = renderComponent({text, onClick, className: 'test-class', id: 'test-id', style: {opacity: '0.5'}})
+        const result = render(CopyToClipboardButton, {getWindow, text, onClick, className: 'test-class', id: 'test-id', style: {opacity: '0.5'}})
         const component = ReactTestUtils.findRenderedDOMComponentWithClass(result, 'copy-to-clipboard')
 
         ReactTestUtils.Simulate.click(component)
@@ -100,7 +97,7 @@ describe('CopyToClipboard', () => {
       })
 
       it('calls the provided callback', () => {
-        const result = renderComponent({text, onClick, className: 'test-class', id: 'test-id', style: {opacity: '0.5'}})
+        const result = render(CopyToClipboardButton, {getWindow, text, onClick, className: 'test-class', id: 'test-id', style: {opacity: '0.5'}})
         const component = ReactTestUtils.findRenderedDOMComponentWithClass(result, 'copy-to-clipboard')
 
         ReactTestUtils.Simulate.click(component)

--- a/library/src/pivotal-ui-react/copy-to-clipboard/copy-to-clipboard.js
+++ b/library/src/pivotal-ui-react/copy-to-clipboard/copy-to-clipboard.js
@@ -11,22 +11,22 @@ export class CopyToClipboard extends React.Component {
   static propTypes = {
     text: types.string.isRequired,
     onClick: types.func,
-    copyWindow: types.object,
-  };
+    getWindow: types.func,
+  }
 
   static defaultProps = {
-    copyWindow: window,
+    getWindow: () => window,
   }
 
   click = ({props, text}, e) => {
-    const {copyWindow} = this.props
-    copy(copyWindow, copyWindow.document, text);
+    const window = this.props.getWindow()
+    copy(window, window.document, text);
     const {onClick} = props;
     if(onClick) onClick(e);
   }
 
   render() {
-    const {children, text, onClick, copyWindow, ...others} = this.props;
+    const {children, text, onClick, getWindow, ...others} = this.props;
     const obj = {props: this.props, text: null};
 
     const anchorProps = mergeProps(others, {
@@ -46,13 +46,13 @@ export class CopyToClipboardButton extends React.Component {
   static propTypes = {
     text: types.string,
     onClick: types.func,
-    copyWindow: types.object
+    getWindow: types.func
   };
 
   static defaultProps = {
     onClick() {
     },
-    copyWindow: window
+    getWindow: () => window
   };
 
   constructor(props, context) {
@@ -74,7 +74,7 @@ export class CopyToClipboardButton extends React.Component {
     const copyProps = mergeProps(props, {
       className: 'copy-to-clipboard-button',
       onClick: this.click,
-      copyWindow: this.props.copyWindow
+      getWindow: this.props.getWindow
     });
 
     const button = (<div className="clipboard-button">


### PR DESCRIPTION
- do not default a property that points to window so that the component
  can be rendered in a non-browser environment

Signed-off-by: Ryan Dy <rdy@pivotal.io>