### PR TITLE
Merge both panels .panel rule-sets

### DIFF
--- a/library/src/pivotal-ui/components/panels/panels.scss
+++ b/library/src/pivotal-ui/components/panels/panels.scss
@@ -12,6 +12,8 @@
   }
   margin: 0;
   //background-color: transparent; // Bootstrap Override
+
+  border: none; //Bootstrap override
 }
 
 .panel-body {
@@ -164,10 +166,6 @@
   &.panel-off:before {
     border-top: ($base-unit*3) solid $gray-4;
   }
-}
-
-.panel {
-  border: none; //Bootstrap override
 }
 
 .panel-shadow {


### PR DESCRIPTION
A second .panels rule-set was introduced in v8.0.0 that sets `border:
none`, but was overriding `border` rules defined in other classes like
.panel-simple and .panel-basic-alt.

By merging these two rule-sets, I believe the desired behavior of giving
the .panel no border, but allowing other panel types to set a border, is
restored.

/cc @chentom88 @cwang-pivotal 