### PR TITLE
Fix bug with select value

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "simple-headless-chrome": "^4.3.10",
     "stream-reduce": "^1.0.3",
     "stream-series": "^0.1.1",
+    "stringifier": "^1.3.0",
     "strong-wait-till-listening": "^1.0.1",
     "style-loader": "^0.18.2",
     "through": "^2.3.8",

--- a/spec/pivotal-ui-react/select/select_spec.js
+++ b/spec/pivotal-ui-react/select/select_spec.js
@@ -113,7 +113,7 @@ describe('Select', () => {
 
       it('calls then onChange callback', () => {
         //cannot assert on event object due to phantomJS limitation
-        expect(onChangeSpy).toHaveBeenCalledWith(jasmine.any(Object));
+        expect(onChangeSpy).toHaveBeenCalledWith(jasmine.any(Object), 'one');
       });
 
       it('updates the selected value', () => {

--- a/spec/pivotal-ui-react/spec_helper.js
+++ b/spec/pivotal-ui-react/spec_helper.js
@@ -10,6 +10,7 @@ import './support/bluebird';
 import './support/set_immediate';
 import 'pivotal-js-jasmine-matchers';
 import ReactTestUtils from 'react-dom/test-utils';
+import stringifier from 'stringifier';
 
 export const findByClass = ReactTestUtils.findRenderedDOMComponentWithClass;
 export const findAllByClass = ReactTestUtils.scryRenderedDOMComponentsWithClass;
@@ -20,6 +21,11 @@ export const clickOn = ReactTestUtils.Simulate.click;
 MockNextTick.install();
 
 delete ReactTestUtils.renderIntoDocument;
+
+jasmine.pp = function(obj) {
+  const stringifierInstance = stringifier({maxDepth: 5, indent: '  '});
+  return stringifierInstance(obj);
+};
 
 Object.assign(global, {
   jQuery,

--- a/src/react/select/select.js
+++ b/src/react/select/select.js
@@ -38,13 +38,12 @@ export class Select extends mixin(React.Component).with(Scrim, Transition) {
   toggle = () => this.setState({open: !this.state.open});
 
   select = e => {
-    const value = e.target.getAttribute('value');
-    Object.defineProperty(e.target, 'value', {value});
+    const value = e.target.getAttribute('data-value');
 
     this.setState({
       open: false,
       uncontrolledValue: value
-    }, this.props.onChange && this.props.onChange(e));
+    }, this.props.onChange && this.props.onChange(e, value));
   };
 
   scrimClick = () => this.setState({open: false});
@@ -63,7 +62,7 @@ export class Select extends mixin(React.Component).with(Scrim, Transition) {
         className,
         key: value,
         role: 'button',
-        value,
+        'data-value': value,
         onClick: this.select
       }}>{label}</li>);
       return memo;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2127,13 +2127,13 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
+core-js@^2.0.0, core-js@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
+
 core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
-
-core-js@^2.5.0:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -8684,6 +8684,14 @@ string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
+stringifier@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/stringifier/-/stringifier-1.3.0.tgz#def18342f6933db0f2dbfc9aa02175b448c17959"
+  dependencies:
+    core-js "^2.0.0"
+    traverse "^0.6.6"
+    type-name "^2.0.1"
+
 stringstream@~0.0.4:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
@@ -9047,6 +9055,10 @@ tough-cookie@>=0.12.0, tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
+traverse@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+
 trie-search@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trie-search/-/trie-search-1.0.1.tgz#eaa2c3ab2810bfa0bfff455a460b6e4ed71c52e9"
@@ -9105,6 +9117,10 @@ type-is@~1.6.10, type-is@~1.6.14, type-is@~1.6.6:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.15"
+
+type-name@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/type-name/-/type-name-2.0.2.tgz#efe7d4123d8ac52afff7f40c7e4dec5266008fb4"
 
 typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"


### PR DESCRIPTION
An `<li>` tag can have a value but it means something different in certain browsers. Use a data-value attribute instead to store that value and call onChange with it separately instead of mutating the target DOM node.