### PR TITLE
Allow manual control of TooltipTrigger visibility

### DIFF
--- a/spec/pivotal-ui-react/tooltip/tooltip_trigger_spec.js
+++ b/spec/pivotal-ui-react/tooltip/tooltip_trigger_spec.js
@@ -129,14 +129,9 @@ describe('TooltipTrigger Component', () => {
       expect(onClick).toHaveBeenCalledWith(jasmine.any(Object));
     });
 
-    it('hides the tooltip when display is false', () => {
-      renderComponent({tooltip: 'Some tooltip content', display: false});
-      expect('.tooltip-container').toHaveClass('tooltip-container-hidden');
-    });
-
-    it('shows the tooltip when display is true', () => {
+    it('does not take the display prop into account', () => {
       renderComponent({tooltip: 'Some tooltip content', display: true});
-      expect('.tooltip-container').toHaveClass('tooltip-container-visible');
+      expect('.tooltip-container').toHaveClass('tooltip-container-hidden');
     });
   });
 
@@ -172,14 +167,9 @@ describe('TooltipTrigger Component', () => {
       expect('.tooltip-container').toHaveClass('tooltip-container-hidden');
     });
 
-    it('hides the tooltip when display is false', () => {
-      renderComponent({trigger: 'click', tooltip: 'Some tooltip content', display: false});
-      expect('.tooltip-container').toHaveClass('tooltip-container-hidden');
-    });
-
-    it('shows the tooltip when display is true', () => {
+    it('does not take the display prop into account', () => {
       renderComponent({trigger: 'click', tooltip: 'Some tooltip content', display: true});
-      expect('.tooltip-container').toHaveClass('tooltip-container-visible');
+      expect('.tooltip-container').toHaveClass('tooltip-container-hidden');
     });
   });
 

--- a/spec/pivotal-ui-react/tooltip/tooltip_trigger_spec.js
+++ b/spec/pivotal-ui-react/tooltip/tooltip_trigger_spec.js
@@ -128,6 +128,11 @@ describe('TooltipTrigger Component', () => {
       jasmine.clock().tick(1);
       expect(onClick).toHaveBeenCalledWith(jasmine.any(Object));
     });
+
+    it('does not take the display prop into account', () => {
+      renderComponent({tooltip: 'Some tooltip content', display: true});
+      expect('.tooltip-container').toHaveClass('tooltip-container-hidden');
+    });
   });
 
   describe('trigger is click', () => {
@@ -160,6 +165,26 @@ describe('TooltipTrigger Component', () => {
       expect('.tooltip-container').toHaveClass('tooltip-container-visible');
       jasmine.clock().tick(6000);
       expect('.tooltip-container').toHaveClass('tooltip-container-hidden');
+    });
+
+    it('does not take the display prop into account', () => {
+      renderComponent({trigger: 'click', tooltip: 'Some tooltip content', display: true});
+      expect('.tooltip-container').toHaveClass('tooltip-container-hidden');
+    });
+  });
+
+  describe('trigger is manual', () => {
+    const trigger = 'manual';
+    const tooltip = 'Some tooltip content';
+
+    it('hides the tooltip when display is false', () => {
+      renderComponent({trigger, tooltip, display: false});
+      expect('.tooltip-container').toHaveClass('tooltip-container-hidden');
+    });
+
+    it('shows the tooltip when display is true', () => {
+      renderComponent({trigger, tooltip, display: true});
+      expect('.tooltip-container').toHaveClass('tooltip-container-visible');
     });
   });
 

--- a/spec/pivotal-ui-react/tooltip/tooltip_trigger_spec.js
+++ b/spec/pivotal-ui-react/tooltip/tooltip_trigger_spec.js
@@ -129,9 +129,14 @@ describe('TooltipTrigger Component', () => {
       expect(onClick).toHaveBeenCalledWith(jasmine.any(Object));
     });
 
-    it('does not take the display prop into account', () => {
-      renderComponent({tooltip: 'Some tooltip content', display: true});
+    it('hides the tooltip when display is false', () => {
+      renderComponent({tooltip: 'Some tooltip content', display: false});
       expect('.tooltip-container').toHaveClass('tooltip-container-hidden');
+    });
+
+    it('shows the tooltip when display is true', () => {
+      renderComponent({tooltip: 'Some tooltip content', display: true});
+      expect('.tooltip-container').toHaveClass('tooltip-container-visible');
     });
   });
 
@@ -167,9 +172,14 @@ describe('TooltipTrigger Component', () => {
       expect('.tooltip-container').toHaveClass('tooltip-container-hidden');
     });
 
-    it('does not take the display prop into account', () => {
-      renderComponent({trigger: 'click', tooltip: 'Some tooltip content', display: true});
+    it('hides the tooltip when display is false', () => {
+      renderComponent({trigger: 'click', tooltip: 'Some tooltip content', display: false});
       expect('.tooltip-container').toHaveClass('tooltip-container-hidden');
+    });
+
+    it('shows the tooltip when display is true', () => {
+      renderComponent({trigger: 'click', tooltip: 'Some tooltip content', display: true});
+      expect('.tooltip-container').toHaveClass('tooltip-container-visible');
     });
   });
 

--- a/spec/pivotal-ui-react/tooltip/tooltip_trigger_spec.js
+++ b/spec/pivotal-ui-react/tooltip/tooltip_trigger_spec.js
@@ -133,6 +133,17 @@ describe('TooltipTrigger Component', () => {
       renderComponent({tooltip: 'Some tooltip content', display: true});
       expect('.tooltip-container').toHaveClass('tooltip-container-hidden');
     });
+
+    describe('when the display prop changes', () => {
+      beforeEach(() => {
+        renderComponent({tooltip: 'Some tooltip content'});
+        renderComponent({tooltip: 'Some tooltip content', display: true});
+      });
+
+      it('takes the display prop into account', () => {
+        expect('.tooltip-container').toHaveClass('tooltip-container-visible');
+      });
+    });
   });
 
   describe('trigger is click', () => {
@@ -171,6 +182,17 @@ describe('TooltipTrigger Component', () => {
       renderComponent({trigger: 'click', tooltip: 'Some tooltip content', display: true});
       expect('.tooltip-container').toHaveClass('tooltip-container-hidden');
     });
+
+    describe('when the display prop changes', () => {
+      beforeEach(() => {
+        renderComponent({trigger: 'click', tooltip: 'Some tooltip content'});
+        renderComponent({trigger: 'click', tooltip: 'Some tooltip content', display: true});
+      });
+
+      it('takes the display prop into account', () => {
+        expect('.tooltip-container').toHaveClass('tooltip-container-visible');
+      });
+    });
   });
 
   describe('trigger is manual', () => {
@@ -185,6 +207,19 @@ describe('TooltipTrigger Component', () => {
     it('shows the tooltip when display is true', () => {
       renderComponent({trigger, tooltip, display: true});
       expect('.tooltip-container').toHaveClass('tooltip-container-visible');
+    });
+
+    describe('when the trigger prop changes', () => {
+      const nextTrigger = 'hover';
+
+      beforeEach(() => {
+        renderComponent({trigger, tooltip, display: true});
+        renderComponent({trigger: nextTrigger, tooltip, display: true});
+      });
+
+      it('takes the trigger prop into account', () => {
+        expect('.tooltip-container').toHaveClass('tooltip-container-hidden');
+      });
     });
   });
 

--- a/src/react/tooltip/tooltip.js
+++ b/src/react/tooltip/tooltip.js
@@ -69,7 +69,7 @@ export class TooltipTrigger extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = {visible: false};
+    this.state = {visible: props.trigger === 'manual' ? props.display : false};
     this.clickHandler = this.clickHandler.bind(this);
   }
 
@@ -89,6 +89,18 @@ export class TooltipTrigger extends React.Component {
     }, this.props.clickHideDelay);
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.trigger !== nextProps.trigger) {
+      if (nextProps.trigger === 'manual') {
+        this.setState({visible: nextProps.display});
+      } else {
+        this.setState({visible: false});
+      }
+    } else if (this.props.display !== nextProps.display) {
+      this.setState({visible: nextProps.display});
+    }
+  }
+
   componentDidUpdate(prevProps, prevState) {
     if(prevState.visible && !this.state.visible) {
       this.props.onExited();
@@ -97,16 +109,9 @@ export class TooltipTrigger extends React.Component {
     }
   }
 
-  getVisible() {
-    if (this.props.trigger === 'manual') {
-      return this.props.display;
-    }
-    return this.state.visible;
-  }
-
   render() {
     const {isSticky, placement, tooltip, trigger, className, clickHideDelay, onEntered, onExited, theme, size, onClick, display, ...others} = this.props;
-    const visible = this.getVisible();
+    const {visible} = this.state;
 
     let placementClass;
     if(placement !== 'top') {

--- a/src/react/tooltip/tooltip.js
+++ b/src/react/tooltip/tooltip.js
@@ -93,12 +93,10 @@ export class TooltipTrigger extends React.Component {
     const triggerChanged = this.props.trigger !== nextProps.trigger;
     const displayChanged = this.props.display !== nextProps.display;
 
-    if (triggerChanged) {
-      if (nextProps.trigger === 'manual') {
-        this.setState({visible: nextProps.display});
-      } else {
-        this.setState({visible: false});
-      }
+    if (triggerChanged && nextProps.trigger === 'manual') {
+      this.setState({visible: nextProps.display});
+    } else if (triggerChanged) {
+      this.setState({visible: false});
     } else if (displayChanged) {
       this.setState({visible: nextProps.display});
     }

--- a/src/react/tooltip/tooltip.js
+++ b/src/react/tooltip/tooltip.js
@@ -41,9 +41,10 @@ export class Tooltip extends React.PureComponent {
 
 export class TooltipTrigger extends React.Component {
   static propTypes = {
+    display: PropTypes.bool,
     tooltip: PropTypes.oneOfType([PropTypes.node, PropTypes.object]).isRequired,
     placement: PropTypes.oneOf(['left', 'right', 'bottom', 'top']),
-    trigger: PropTypes.oneOf(['hover', 'click']),
+    trigger: PropTypes.oneOf(['manual', 'hover', 'click']),
     clickHideDelay: PropTypes.number,
     onClick: PropTypes.func,
     onEntered: PropTypes.func,
@@ -54,6 +55,7 @@ export class TooltipTrigger extends React.Component {
   };
 
   static defaultProps = {
+    display: false,
     placement: 'top',
     trigger: 'hover',
     clickHideDelay: 1000,
@@ -95,9 +97,16 @@ export class TooltipTrigger extends React.Component {
     }
   }
 
+  getVisible() {
+    if (this.props.trigger === 'manual') {
+      return this.props.display;
+    }
+    return this.state.visible;
+  }
+
   render() {
-    const {isSticky, placement, tooltip, trigger, className, clickHideDelay, onEntered, onExited, theme, size, onClick, ...others} = this.props;
-    const {visible} = this.state;
+    const {isSticky, placement, tooltip, trigger, className, clickHideDelay, onEntered, onExited, theme, size, onClick, display, ...others} = this.props;
+    const visible = this.getVisible();
 
     let placementClass;
     if(placement !== 'top') {
@@ -108,6 +117,9 @@ export class TooltipTrigger extends React.Component {
     switch(trigger) {
       case 'click':
         triggerHandler = {onClick: e => this.clickHandler(e, onClick)};
+        break;
+      case 'manual':
+        triggerHandler = {};
         break;
       default:
         triggerHandler = {

--- a/src/react/tooltip/tooltip.js
+++ b/src/react/tooltip/tooltip.js
@@ -55,7 +55,7 @@ export class TooltipTrigger extends React.Component {
   };
 
   static defaultProps = {
-    display: undefined,
+    display: false,
     placement: 'top',
     trigger: 'hover',
     clickHideDelay: 1000,
@@ -98,10 +98,10 @@ export class TooltipTrigger extends React.Component {
   }
 
   getVisible() {
-    if (this.props.display === undefined) {
-      return this.state.visible;
+    if (this.props.trigger === 'manual') {
+      return this.props.display;
     }
-    return this.props.display;
+    return this.state.visible;
   }
 
   render() {

--- a/src/react/tooltip/tooltip.js
+++ b/src/react/tooltip/tooltip.js
@@ -55,7 +55,7 @@ export class TooltipTrigger extends React.Component {
   };
 
   static defaultProps = {
-    display: false,
+    display: undefined,
     placement: 'top',
     trigger: 'hover',
     clickHideDelay: 1000,
@@ -98,10 +98,10 @@ export class TooltipTrigger extends React.Component {
   }
 
   getVisible() {
-    if (this.props.trigger === 'manual') {
-      return this.props.display;
+    if (this.props.display === undefined) {
+      return this.state.visible;
     }
-    return this.state.visible;
+    return this.props.display;
   }
 
   render() {

--- a/src/react/tooltip/tooltip.js
+++ b/src/react/tooltip/tooltip.js
@@ -90,13 +90,16 @@ export class TooltipTrigger extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.trigger !== nextProps.trigger) {
+    const triggerChanged = this.props.trigger !== nextProps.trigger;
+    const displayChanged = this.props.display !== nextProps.display;
+
+    if (triggerChanged) {
       if (nextProps.trigger === 'manual') {
         this.setState({visible: nextProps.display});
       } else {
         this.setState({visible: false});
       }
-    } else if (this.props.display !== nextProps.display) {
+    } else if (displayChanged) {
       this.setState({visible: nextProps.display});
     }
   }


### PR DESCRIPTION
Resolves #536.

Adds the ability to manually control the visibility of Tooltips used with the TooltipTrigger, bringing it inline with the functionality of the OverlayTrigger.