### PR TITLE
Style Close Min Max Terminal Buttons for Code component

### DIFF
--- a/src/css/code/code.scss
+++ b/src/css/code/code.scss
@@ -107,6 +107,18 @@ pre.pre-scrollable {
       display: inline-block;
       margin-right: 15px;
     }
+    
+    &.color li {
+      &:nth-child(1){
+        background-color: $terminal-dot-close;
+      }
+      &:nth-child(2){
+        background-color: $terminal-dot-minimize;
+      }
+      &:nth-child(3){
+        background-color: $terminal-dot-maximize;
+      }
+    }
   }
 
   pre[class*="language-"] {

--- a/src/css/pui-variables.scss
+++ b/src/css/pui-variables.scss
@@ -1118,6 +1118,10 @@ $pre-color: $gray-dark !default;
 $pre-border-color: #ccc !default;
 $pre-scrollable-max-height: 340px !default;
 
+$terminal-dot-minimize: #F6BE4F;
+$terminal-dot-maximize: #66CD58;
+$terminal-dot-close: #ED6B62;
+
 // Container sizes
 // --------------------------------------------------
 


### PR DESCRIPTION
This PR adds the standard Mac colors to the close, min, and max terminal buttons (dots) via nth-child selectors.
