### PR TITLE
CheckboxDropdown accepts initial state for box checked-ness.

### DIFF
--- a/spec/pivotal-ui-react/checkbox-dropdown/checkbox-dropdown_spec.js
+++ b/spec/pivotal-ui-react/checkbox-dropdown/checkbox-dropdown_spec.js
@@ -4,238 +4,260 @@ import {CheckboxDropdown} from '../../../src/react/checkbox-dropdown';
 describe('checkbox dropdown', () => {
   let subject;
 
-  beforeEach(() => {
-    subject = ReactDOM.render(<CheckboxDropdown labels={['item #1', 'item #2', 'item #3']} />, root);
-  });
+  describe('for an object of labels', () => {
+    let labels;
 
-  describe('on initial render', () => {
-    it('on initialization state.open is false', () => {
-      expect(subject.state.open).toBeFalsy();
-    });
-
-    it('renders the items passed in props', () => {
-      expect($('.checkbox-dropdown-item-checkbox:eq(0)')).toHaveText('ALL');
-      expect($('.checkbox-dropdown-item-checkbox:eq(1)')).toHaveText('item #1');
-      expect($('.checkbox-dropdown-item-checkbox:eq(2)')).toHaveText('item #2');
-      expect($('.checkbox-dropdown-item-checkbox:eq(3)')).toHaveText('item #3');
-    });
-
-    it('renders the items with labels and labelClassNames', () => {
-      expect($('.pui-checkbox-label:eq(0)')).toHaveClass('pui-checkbox-dropdown-item-label');
-      expect($('.pui-checkbox-label:eq(1)')).toHaveClass('pui-checkbox-dropdown-item-label');
-      expect($('.pui-checkbox-label:eq(2)')).toHaveClass('pui-checkbox-dropdown-item-label');
-      expect($('.pui-checkbox-label:eq(3)')).toHaveClass('pui-checkbox-dropdown-item-label');
-    });
-
-    it('has the text "ALL"', () => {
-      expect($('.dropdown > button')).toHaveText('ALL');
-    });
-
-    it('all the checkboxes are checked', () => {
-      expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeTruthy();
-      expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeTruthy();
-      expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeTruthy();
-      expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeTruthy();
-    });
-
-    it('initializes the state to true for all the options', () => {
-      expect(Object.values(subject.state.options).every(val => val)).toBeTruthy();
-    });
-
-    it('all selected returns true', () => {
-      expect(subject.allSelected()).toBeTruthy();
-    });
-  });
-
-  describe('unselecting a checkbox option', () => {
     beforeEach(() => {
-      $('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]').click();
+      labels = {'item #1': true, 'item #2': false, 'item #3': true};
+      subject = ReactDOM.render(<CheckboxDropdown labels={labels} />, root);
     });
 
-    it('the title changes to show the selected options', () => {
-      expect($('.dropdown > button')).toHaveText('item #1, item #3');
+    it('initializes the state to the labels for all the options', () => {
+      expect(subject.state.options).toEqual(labels);
     });
 
-    it('will unselect the "ALL" checkbox', () => {
+    it('checks the configured labels', () => {
       expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeFalsy();
       expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeTruthy();
       expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeFalsy();
       expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeTruthy();
     });
+  });
 
-    describe('reselecting the checkbox option', () => {
+  describe('for an array of labels', () => {
+    beforeEach(() => {
+      subject = ReactDOM.render(<CheckboxDropdown labels={['item #1', 'item #2', 'item #3']}/>, root);
+    });
+
+    describe('on initial render', () => {
+      it('on initialization state.open is false', () => {
+        expect(subject.state.open).toBeFalsy();
+      });
+
+      it('renders the items passed in props', () => {
+        expect($('.checkbox-dropdown-item-checkbox:eq(0)')).toHaveText('ALL');
+        expect($('.checkbox-dropdown-item-checkbox:eq(1)')).toHaveText('item #1');
+        expect($('.checkbox-dropdown-item-checkbox:eq(2)')).toHaveText('item #2');
+        expect($('.checkbox-dropdown-item-checkbox:eq(3)')).toHaveText('item #3');
+      });
+
+      it('renders the items with labels and labelClassNames', () => {
+        expect($('.pui-checkbox-label:eq(0)')).toHaveClass('pui-checkbox-dropdown-item-label');
+        expect($('.pui-checkbox-label:eq(1)')).toHaveClass('pui-checkbox-dropdown-item-label');
+        expect($('.pui-checkbox-label:eq(2)')).toHaveClass('pui-checkbox-dropdown-item-label');
+        expect($('.pui-checkbox-label:eq(3)')).toHaveClass('pui-checkbox-dropdown-item-label');
+      });
+
+      it('has the text "ALL"', () => {
+        expect($('.dropdown > button')).toHaveText('ALL');
+      });
+
+      it('all the checkboxes are checked', () => {
+        expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeTruthy();
+        expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeTruthy();
+        expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeTruthy();
+        expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeTruthy();
+      });
+
+      it('initializes the state to true for all the options', () => {
+        expect(Object.values(subject.state.options).every(val => val)).toBeTruthy();
+      });
+
+      it('all selected returns true', () => {
+        expect(subject.allSelected()).toBeTruthy();
+      });
+    });
+
+    describe('unselecting a checkbox option', () => {
       beforeEach(() => {
         $('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]').click();
       });
 
-      it('the title text displays "ALL"', () => {
-        expect($('.dropdown > button')).toHaveText('ALL');
+      it('the title changes to show the selected options', () => {
+        expect($('.dropdown > button')).toHaveText('item #1, item #3');
       });
 
-      it('will reselect the all checkboxes', () => {
-        expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeTruthy();
+      it('will unselect the "ALL" checkbox', () => {
+        expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeFalsy();
         expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeTruthy();
-        expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeTruthy();
+        expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeFalsy();
         expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeTruthy();
       });
-    });
 
-    describe('reselecting the "ALL" checkbox option', () => {
-      beforeEach(() => {
-        $('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]').click();
+      describe('reselecting the checkbox option', () => {
+        beforeEach(() => {
+          $('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]').click();
+        });
+
+        it('the title text displays "ALL"', () => {
+          expect($('.dropdown > button')).toHaveText('ALL');
+        });
+
+        it('will reselect the all checkboxes', () => {
+          expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeTruthy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeTruthy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeTruthy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeTruthy();
+        });
       });
 
-      it('the title text displays "ALL"', () => {
-        expect($('.dropdown > button')).toHaveText('ALL');
+      describe('reselecting the "ALL" checkbox option', () => {
+        beforeEach(() => {
+          $('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]').click();
+        });
+
+        it('the title text displays "ALL"', () => {
+          expect($('.dropdown > button')).toHaveText('ALL');
+        });
+
+        it('will reselect the all checkboxes', () => {
+          expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeTruthy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeTruthy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeTruthy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeTruthy();
+        });
       });
-
-      it('will reselect the all checkboxes', () => {
-        expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeTruthy();
-        expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeTruthy();
-        expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeTruthy();
-        expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeTruthy();
-      });
-    });
-  });
-
-  describe('unselecting all checkbox options', () => {
-    beforeEach(() => {
-      $('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]').click();
-      $('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]').click();
-      $('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]').click();
     });
 
-    it('the title changes to show "NONE"', () => {
-      expect($('.dropdown > button')).toHaveText('NONE');
-    });
-
-    it('will unselect the "ALL" checkbox', () => {
-      expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeFalsy();
-      expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeFalsy();
-      expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeFalsy();
-      expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeFalsy();
-    });
-
-    describe('reselecting the unchecked checkbox options', () => {
+    describe('unselecting all checkbox options', () => {
       beforeEach(() => {
         $('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]').click();
         $('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]').click();
         $('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]').click();
       });
 
-      it('the title text displays "ALL"', () => {
-        expect($('.dropdown > button')).toHaveText('ALL');
+      it('the title changes to show "NONE"', () => {
+        expect($('.dropdown > button')).toHaveText('NONE');
       });
 
-      it('will reselect all the checkboxes', () => {
-        expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeTruthy();
-        expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeTruthy();
-        expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeTruthy();
-        expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeTruthy();
-      });
-    });
-
-    describe('reselecting the "ALL" checkbox option', () => {
-      beforeEach(() => {
-        $('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]').click();
-      });
-
-      it('the title text displays "ALL"', () => {
-        expect($('.dropdown > button')).toHaveText('ALL');
-      });
-
-      it('will reselect all the checkboxes', () => {
-        expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeTruthy();
-        expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeTruthy();
-        expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeTruthy();
-        expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeTruthy();
-      });
-    });
-  });
-
-  describe('unselecting the "ALL" checkbox option', () => {
-    beforeEach(() => {
-      $('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]').click();
-    });
-
-    it('the title changes to show "NONE"', () => {
-      expect($('.dropdown > button')).toHaveText('NONE');
-    });
-
-    it('will unselect all checkboxes', () => {
-      expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeFalsy();
-      expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeFalsy();
-      expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeFalsy();
-      expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeFalsy();
-    });
-
-    describe('reselecting any checkbox options', () => {
-      beforeEach(() => {
-        $('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]').click();
-        $('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]').click();
-      });
-
-      it('the title changes to show the selected options', () => {
-        expect($('.dropdown > button')).toHaveText('item #2, item #3');
-      });
-
-      it('will reselect some of the checkboxes', () => {
+      it('will unselect the "ALL" checkbox', () => {
         expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeFalsy();
         expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeFalsy();
-        expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeTruthy();
-        expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeTruthy();
+        expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeFalsy();
+        expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeFalsy();
+      });
+
+      describe('reselecting the unchecked checkbox options', () => {
+        beforeEach(() => {
+          $('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]').click();
+          $('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]').click();
+          $('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]').click();
+        });
+
+        it('the title text displays "ALL"', () => {
+          expect($('.dropdown > button')).toHaveText('ALL');
+        });
+
+        it('will reselect all the checkboxes', () => {
+          expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeTruthy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeTruthy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeTruthy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeTruthy();
+        });
+      });
+
+      describe('reselecting the "ALL" checkbox option', () => {
+        beforeEach(() => {
+          $('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]').click();
+        });
+
+        it('the title text displays "ALL"', () => {
+          expect($('.dropdown > button')).toHaveText('ALL');
+        });
+
+        it('will reselect all the checkboxes', () => {
+          expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeTruthy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeTruthy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeTruthy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeTruthy();
+        });
       });
     });
 
-    describe('reselecting the "ALL" checkbox option', () => {
+    describe('unselecting the "ALL" checkbox option', () => {
       beforeEach(() => {
         $('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]').click();
       });
 
-      it('the title changes to show "ALL"', () => {
-        expect($('.dropdown > button')).toHaveText('ALL');
+      it('the title changes to show "NONE"', () => {
+        expect($('.dropdown > button')).toHaveText('NONE');
       });
 
-      it('will reselect all the checkboxes', () => {
-        expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeTruthy();
-        expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeTruthy();
-        expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeTruthy();
-        expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeTruthy();
+      it('will unselect all checkboxes', () => {
+        expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeFalsy();
+        expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeFalsy();
+        expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeFalsy();
+        expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeFalsy();
+      });
+
+      describe('reselecting any checkbox options', () => {
+        beforeEach(() => {
+          $('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]').click();
+          $('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]').click();
+        });
+
+        it('the title changes to show the selected options', () => {
+          expect($('.dropdown > button')).toHaveText('item #2, item #3');
+        });
+
+        it('will reselect some of the checkboxes', () => {
+          expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeFalsy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeFalsy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeTruthy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeTruthy();
+        });
+      });
+
+      describe('reselecting the "ALL" checkbox option', () => {
+        beforeEach(() => {
+          $('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]').click();
+        });
+
+        it('the title changes to show "ALL"', () => {
+          expect($('.dropdown > button')).toHaveText('ALL');
+        });
+
+        it('will reselect all the checkboxes', () => {
+          expect($('.checkbox-dropdown-item-checkbox:eq(0) input[type="checkbox"]')[0].checked).toBeTruthy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(1) input[type="checkbox"]')[0].checked).toBeTruthy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]')[0].checked).toBeTruthy();
+          expect($('.checkbox-dropdown-item-checkbox:eq(3) input[type="checkbox"]')[0].checked).toBeTruthy();
+        });
       });
     });
-  });
 
-  describe('when interacting with the checkboxes', () => {
-    let testableFn;
-    beforeEach(() => {
-      testableFn = jasmine.createSpy('testableFn');
-      subject::setProps({onChange: testableFn});
-      $('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]').click();
-    });
+    describe('when interacting with the checkboxes', () => {
+      let testableFn;
+      beforeEach(() => {
+        testableFn = jasmine.createSpy('testableFn');
+        subject::setProps({onChange: testableFn});
+        $('.checkbox-dropdown-item-checkbox:eq(2) input[type="checkbox"]').click();
+      });
 
-    it('calls the onChange callback', () => {
-      expect(testableFn).toHaveBeenCalledWith({
-        'item #1': true,
-        'item #2': false,
-        'item #3': true
+      it('calls the onChange callback', () => {
+        expect(testableFn).toHaveBeenCalledWith({
+          'item #1': true,
+          'item #2': false,
+          'item #3': true
+        });
       });
     });
-  });
 
-  describe('when clicking on a label', () => {
-    let onChange;
+    describe('when clicking on a label', () => {
+      let onChange;
 
-    beforeEach(() => {
-      onChange = jasmine.createSpy('onChange');
-      subject::setProps({onChange});
-      $('.pui-checkbox-label:eq(2)').click();
-    });
+      beforeEach(() => {
+        onChange = jasmine.createSpy('onChange');
+        subject::setProps({onChange});
+        $('.pui-checkbox-label:eq(2)').click();
+      });
 
-    it('calls the onChange callback', () => {
-      expect(onChange).toHaveBeenCalledWith({
-        'item #1': true,
-        'item #2': false,
-        'item #3': true
+      it('calls the onChange callback', () => {
+        expect(onChange).toHaveBeenCalledWith({
+          'item #1': true,
+          'item #2': false,
+          'item #3': true
+        });
       });
     });
   });

--- a/src/react/checkbox-dropdown/checkbox-dropdown.js
+++ b/src/react/checkbox-dropdown/checkbox-dropdown.js
@@ -16,7 +16,7 @@ export class CheckboxDropdown extends React.Component {
     onChange: PropTypes.func,
     size: PropTypes.oneOf(['normal', 'large', 'small']),
     split: PropTypes.bool,
-    labels: PropTypes.array
+    labels: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   };
 
   static defaultProps = {
@@ -27,10 +27,13 @@ export class CheckboxDropdown extends React.Component {
   constructor(props, context) {
     super(props, context);
     const {labels} = this.props;
-    const options = labels.reduce((result, item) => {
-      result[item] = true;
-      return result;
-    }, {});
+    let options = labels;
+    if (Array.isArray(labels) === true) {
+      options = labels.reduce((result, item) => {
+        result[item] = true;
+        return result;
+      }, {});
+    }
     this.state = {open: false, options};
   }
 
@@ -79,12 +82,13 @@ export class CheckboxDropdown extends React.Component {
     const {labels, onChange, className, ...dropDownProps} = this.props;
     const {options} = this.state;
 
-    const dropdownItems = labels.map(label => {
+    const dropdownItems = Object.entries(options).map(([label, checked]) => {
+
       return (
         <Checkbox className="checkbox-dropdown-item-checkbox man"
                   labelClassName="pui-checkbox-dropdown-item-label"
                   key={label}
-                  checked={options[label]}
+                  checked={checked}
                   onChange={doNothing}
                   onClick={e => this.toggleOption(e, label)}>{label}</Checkbox>
       );


### PR DESCRIPTION
This is a pull request to make CheckboxDropdown accept initial state for whether a box is checked or not.

The labels prop can now either be an array, like the existing interface, or an object.  If it is an object, the keys are the labels for the checkboxes and the values are booleans representing whether a box is checked or not.

It looks like we changed many tests, but we just had to namespace the different label states, b/c our change was in the constructor.