### PR TITLE
Form perf improvements

### DIFF
--- a/src/react/forms/form.js
+++ b/src/react/forms/form.js
@@ -85,22 +85,29 @@ export class Form extends React.Component {
     if (this.props.onModified) this.props.onModified(false);
   }
 
-  onChangeCheckbox = (name, cb = noop) => val => {
+  onChangeCheckbox = (name, cb) => val => {
     if (typeof val.persist === 'function') val.persist();
-    this.setValues({[name]: !this.state.current[name]}, () => cb(val));
+
+    const nextValue = {[name]: !this.state.current[name]};
+    if (cb) this.setValues(nextValue, () => cb(val));
+    else this.setValues(nextValue);
   };
 
-  onChange = (name, validator, cb = noop) => val => {
+  onChange = (name, validator, cb) => val => {
     const {initial} = this.state;
     const value = val.target && 'value' in val.target ? val.target.value : val;
     const nextState = {current: {...this.state.current, [name]: value}};
+
     const error = validator && validator(value);
     if (!error) {
       nextState.errors = {...this.state.errors};
       delete nextState.errors[name];
     }
+
     if (typeof val.persist === 'function') val.persist();
-    this.setState(nextState, () => cb(val));
+
+    if (cb) this.setState(nextState, () => cb(val));
+    else this.setState(nextState);
 
     if (this.props.onModified) this.props.onModified(!deepEqual(initial, nextState.current));
   };


### PR DESCRIPTION
Addresses #577 

This PR makes a number of small performance improvements to the `Form` component. We have known that the `Form` was relatively slow for a while, but it was never serious enough to warrant further investigation. However, today another Pivotal team showed us that our component was unusably slow for a form with ~500 inputs. I would like to enable them to use our component, if possible.

These changes make the `Form` feel significantly more responsive with a large number of fields. The changes that helped the most were doing less looping over the `fields` (e.g. instead of a `.map().filter().reduce()`, just do a `for-in`), and preventing deep-equality checks where we didn't need them.

There is probably more we could do to improve performance, but this felt like a handful of easy wins with minimal changes (no test/interface changes). And I observed an improvement in my testing.