### PR TITLE
Fix nested flex issue on Alerts

### DIFF
--- a/src/css/alerts/alerts.scss
+++ b/src/css/alerts/alerts.scss
@@ -6,10 +6,6 @@
   padding: 8px;
   margin: 0;
 
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-
   border-radius: $alert-border-radius;
 
   a.pui-alert-link, a.alert-link {


### PR DESCRIPTION
We noticed that the `Alert` component is defined as a flexbox in it's `scss` file, but also has a flexbox grid as it's children. This produced a bug on App SSO, and after discussion with Pivotal UI team, we determined that the behavior was redundant and should be merged.

We experimented by removing the outer flex but this did not work, the `squish` bug still occurred. This change fixes the issue by removing flex on the outer div.

Weird flex but ok. 👌

/cc @jberney 