### PR TITLE
Check required fields on submit

### DIFF
--- a/spec/pivotal-ui-react/forms/form_spec.js
+++ b/spec/pivotal-ui-react/forms/form_spec.js
@@ -8,10 +8,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 describe('Form', () => {
-  let Buttons, subject, afterSubmit;
+  let Buttons, subject, afterSubmit, onSubmitError;
 
   beforeEach(() => {
     afterSubmit = jasmine.createSpy('afterSubmit');
+    onSubmitError = jasmine.createSpy('onSubmitError');
     Buttons = jasmine.createSpy('Buttons');
     Buttons.and.callFake(({canSubmit, canReset, reset}) => (
       <div>
@@ -27,7 +28,7 @@ describe('Form', () => {
     beforeEach(() => {
       fields = {name: {initialValue: 'some-name'}};
       subject = ReactDOM.render(
-        <Form {...{className: 'some-form', afterSubmit, fields}}>
+        <Form {...{className: 'some-form', onSubmitError, afterSubmit, fields}}>
           {({fields: {name}, ...rest}) => (
             <Grid>
               <FlexCol>{name}</FlexCol>
@@ -94,7 +95,7 @@ describe('Form', () => {
 
       it('renders buttons ', () => {
         expect('fieldset > .grid:eq(0) > .col:eq(1)').toHaveClass('col-fixed');
-        expect('fieldset > .grid:eq(0) > .col:eq(1) .save').toBeDisabled();
+        expect('fieldset > .grid:eq(0) > .col:eq(1) .save').not.toBeDisabled();
         expect('fieldset > .grid:eq(0) > .col:eq(1) .cancel').not.toBeDisabled();
       });
 
@@ -105,6 +106,32 @@ describe('Form', () => {
 
         it('resets the name', () => {
           expect('fieldset > .grid:eq(0) > .col:eq(0) input').toHaveValue('some-name');
+        });
+      });
+
+      describe('when submitting the form', () => {
+        let caught;
+
+        beforeEach(() => {
+          try {
+            $('.form').simulate('submit');
+          } catch (e) {
+            caught = e;
+          }
+        });
+
+        it('sets errors in the form state', () => {
+          expect(subject.state.errors).toEqual({name: 'Please enter a value.'});
+        });
+
+        it('calls the onSubmitError callback', () => {
+          expect(onSubmitError).toHaveBeenCalledWith(jasmine.objectContaining({
+            message: 'Please enter values for all required fields.'
+          }));
+        });
+
+        it('throws the error', () => {
+          expect(caught).toEqual(jasmine.objectContaining({message: 'Please enter values for all required fields.'}));
         });
       });
     });
@@ -135,13 +162,13 @@ describe('Form', () => {
       });
 
       describe('when clicking the update button', () => {
-        let error, errors, onSubmitError, onSubmit, resolve, reject;
+        let error, errors, onSubmit, resolve, reject;
 
         beforeEach(() => {
           Promise.onPossiblyUnhandledRejection(jasmine.createSpy('reject'));
           error = new Error('invalid');
           errors = {name: 'invalid'};
-          onSubmitError = jasmine.createSpy('onSubmitError').and.returnValue(errors);
+          onSubmitError.and.returnValue(errors);
           onSubmit = jasmine.createSpy('onSubmit');
           onSubmit.and.callFake(() => new Promise((res, rej) => {
             resolve = res;
@@ -509,7 +536,7 @@ describe('Form', () => {
   describe('with two required fields', () => {
     beforeEach(() => {
       subject = ReactDOM.render(
-        <Form {...{className: 'some-form', afterSubmit, fields: {name: {}, password: {}}}}>
+        <Form {...{className: 'some-form', afterSubmit, onSubmitError, fields: {name: {}, password: {}}}}>
           {({fields: {name, password}, ...rest}) => (
             <Grid>
               <FlexCol>{name}</FlexCol>
@@ -545,8 +572,34 @@ describe('Form', () => {
 
       it('renders buttons ', () => {
         expect('.grid:eq(0) .col:eq(2)').toHaveClass('col-fixed');
-        expect('.grid:eq(0) .col:eq(2) .save').toBeDisabled();
+        expect('.grid:eq(0) .col:eq(2) .save').not.toBeDisabled();
         expect('.grid:eq(0) .col:eq(2) .cancel').not.toBeDisabled();
+      });
+
+      describe('when submitting the form', () => {
+        let caught;
+
+        beforeEach(() => {
+          try {
+            $('.form').simulate('submit');
+          } catch (e) {
+            caught = e;
+          }
+        });
+
+        it('sets errors in the form state', () => {
+          expect(subject.state.errors).toEqual({password: 'Please enter a value.'});
+        });
+
+        it('calls the onSubmitError callback', () => {
+          expect(onSubmitError).toHaveBeenCalledWith(jasmine.objectContaining({
+            message: 'Please enter values for all required fields.'
+          }));
+        });
+
+        it('throws the error', () => {
+          expect(caught).toEqual(jasmine.objectContaining({message: 'Please enter values for all required fields.'}));
+        });
       });
 
       describe('when setting the password', () => {
@@ -601,7 +654,7 @@ describe('Form', () => {
     beforeEach(() => {
       optional = jasmine.createSpy('optional');
       subject = ReactDOM.render(
-        <Form {...{className: 'some-form', afterSubmit, fields: {name: {}, password: {optional}}}}>
+        <Form {...{className: 'some-form', afterSubmit, onSubmitError, fields: {name: {}, password: {optional}}}}>
           {({fields: {name, password}, ...rest}) => (
             <Grid>
               <FlexCol>{name}</FlexCol>
@@ -637,8 +690,34 @@ describe('Form', () => {
 
       it('renders buttons ', () => {
         expect('.grid:eq(0) .col:eq(2)').toHaveClass('col-fixed');
-        expect('.grid:eq(0) .col:eq(2) .save').toBeDisabled();
+        expect('.grid:eq(0) .col:eq(2) .save').not.toBeDisabled();
         expect('.grid:eq(0) .col:eq(2) .cancel').not.toBeDisabled();
+      });
+
+      describe('when submitting the form', () => {
+        let caught;
+
+        beforeEach(() => {
+          try {
+            $('.form').simulate('submit');
+          } catch (e) {
+            caught = e;
+          }
+        });
+
+        it('sets errors in the form state', () => {
+          expect(subject.state.errors).toEqual({password: 'Please enter a value.'});
+        });
+
+        it('calls the onSubmitError callback', () => {
+          expect(onSubmitError).toHaveBeenCalledWith(jasmine.objectContaining({
+            message: 'Please enter values for all required fields.'
+          }));
+        });
+
+        it('throws the error', () => {
+          expect(caught).toEqual(jasmine.objectContaining({message: 'Please enter values for all required fields.'}));
+        });
       });
     });
   });
@@ -702,6 +781,7 @@ describe('Form', () => {
         <Form {...{
           className: 'some-form',
           afterSubmit,
+          onSubmitError,
           fields: {name: {initialValue: 'some-name'}, password: {initialValue: 'some-password', optional: true}}
         }}>
           {({fields: {name, password}, ...rest}) => (
@@ -762,8 +842,34 @@ describe('Form', () => {
       });
 
       it('renders buttons in a col-fixed col', () => {
-        expect('.grid:eq(0) .col:eq(2) .save').toBeDisabled();
+        expect('.grid:eq(0) .col:eq(2) .save').not.toBeDisabled();
         expect('.grid:eq(0) .col:eq(2) .cancel').not.toBeDisabled();
+      });
+
+      describe('when submitting the form', () => {
+        let caught;
+
+        beforeEach(() => {
+          try {
+            $('.form').simulate('submit');
+          } catch (e) {
+            caught = e;
+          }
+        });
+
+        it('sets errors in the form state', () => {
+          expect(subject.state.errors).toEqual({name: 'Please enter a value.'});
+        });
+
+        it('calls the onSubmitError callback', () => {
+          expect(onSubmitError).toHaveBeenCalledWith(jasmine.objectContaining({
+            message: 'Please enter values for all required fields.'
+          }));
+        });
+
+        it('throws the error', () => {
+          expect(caught).toEqual(jasmine.objectContaining({message: 'Please enter values for all required fields.'}));
+        });
       });
     });
   });

--- a/spec/pivotal-ui-react/forms/form_spec.js
+++ b/spec/pivotal-ui-react/forms/form_spec.js
@@ -8,11 +8,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 describe('Form', () => {
-  let Buttons, subject, afterSubmit, onSubmitError;
+  let Buttons, subject, afterSubmit;
 
   beforeEach(() => {
     afterSubmit = jasmine.createSpy('afterSubmit');
-    onSubmitError = jasmine.createSpy('onSubmitError');
     Buttons = jasmine.createSpy('Buttons');
     Buttons.and.callFake(({canSubmit, canReset, reset}) => (
       <div>
@@ -28,7 +27,7 @@ describe('Form', () => {
     beforeEach(() => {
       fields = {name: {initialValue: 'some-name'}};
       subject = ReactDOM.render(
-        <Form {...{className: 'some-form', onSubmitError, afterSubmit, fields}}>
+        <Form {...{className: 'some-form', afterSubmit, fields}}>
           {({fields: {name}, ...rest}) => (
             <Grid>
               <FlexCol>{name}</FlexCol>
@@ -95,7 +94,7 @@ describe('Form', () => {
 
       it('renders buttons ', () => {
         expect('fieldset > .grid:eq(0) > .col:eq(1)').toHaveClass('col-fixed');
-        expect('fieldset > .grid:eq(0) > .col:eq(1) .save').not.toBeDisabled();
+        expect('fieldset > .grid:eq(0) > .col:eq(1) .save').toBeDisabled();
         expect('fieldset > .grid:eq(0) > .col:eq(1) .cancel').not.toBeDisabled();
       });
 
@@ -106,32 +105,6 @@ describe('Form', () => {
 
         it('resets the name', () => {
           expect('fieldset > .grid:eq(0) > .col:eq(0) input').toHaveValue('some-name');
-        });
-      });
-
-      describe('when submitting the form', () => {
-        let caught;
-
-        beforeEach(() => {
-          try {
-            $('.form').simulate('submit');
-          } catch (e) {
-            caught = e;
-          }
-        });
-
-        it('sets errors in the form state', () => {
-          expect(subject.state.errors).toEqual({name: 'Please enter a value.'});
-        });
-
-        it('calls the onSubmitError callback', () => {
-          expect(onSubmitError).toHaveBeenCalledWith(jasmine.objectContaining({
-            message: 'Please enter values for all required fields.'
-          }));
-        });
-
-        it('throws the error', () => {
-          expect(caught).toEqual(jasmine.objectContaining({message: 'Please enter values for all required fields.'}));
         });
       });
     });
@@ -162,13 +135,13 @@ describe('Form', () => {
       });
 
       describe('when clicking the update button', () => {
-        let error, errors, onSubmit, resolve, reject;
+        let error, errors, onSubmitError, onSubmit, resolve, reject;
 
         beforeEach(() => {
           Promise.onPossiblyUnhandledRejection(jasmine.createSpy('reject'));
           error = new Error('invalid');
           errors = {name: 'invalid'};
-          onSubmitError.and.returnValue(errors);
+          onSubmitError = jasmine.createSpy('onSubmitError').and.returnValue(errors);
           onSubmit = jasmine.createSpy('onSubmit');
           onSubmit.and.callFake(() => new Promise((res, rej) => {
             resolve = res;
@@ -536,7 +509,7 @@ describe('Form', () => {
   describe('with two required fields', () => {
     beforeEach(() => {
       subject = ReactDOM.render(
-        <Form {...{className: 'some-form', afterSubmit, onSubmitError, fields: {name: {}, password: {}}}}>
+        <Form {...{className: 'some-form', afterSubmit, fields: {name: {}, password: {}}}}>
           {({fields: {name, password}, ...rest}) => (
             <Grid>
               <FlexCol>{name}</FlexCol>
@@ -572,34 +545,8 @@ describe('Form', () => {
 
       it('renders buttons ', () => {
         expect('.grid:eq(0) .col:eq(2)').toHaveClass('col-fixed');
-        expect('.grid:eq(0) .col:eq(2) .save').not.toBeDisabled();
+        expect('.grid:eq(0) .col:eq(2) .save').toBeDisabled();
         expect('.grid:eq(0) .col:eq(2) .cancel').not.toBeDisabled();
-      });
-
-      describe('when submitting the form', () => {
-        let caught;
-
-        beforeEach(() => {
-          try {
-            $('.form').simulate('submit');
-          } catch (e) {
-            caught = e;
-          }
-        });
-
-        it('sets errors in the form state', () => {
-          expect(subject.state.errors).toEqual({password: 'Please enter a value.'});
-        });
-
-        it('calls the onSubmitError callback', () => {
-          expect(onSubmitError).toHaveBeenCalledWith(jasmine.objectContaining({
-            message: 'Please enter values for all required fields.'
-          }));
-        });
-
-        it('throws the error', () => {
-          expect(caught).toEqual(jasmine.objectContaining({message: 'Please enter values for all required fields.'}));
-        });
       });
 
       describe('when setting the password', () => {
@@ -654,7 +601,7 @@ describe('Form', () => {
     beforeEach(() => {
       optional = jasmine.createSpy('optional');
       subject = ReactDOM.render(
-        <Form {...{className: 'some-form', afterSubmit, onSubmitError, fields: {name: {}, password: {optional}}}}>
+        <Form {...{className: 'some-form', afterSubmit, fields: {name: {}, password: {optional}}}}>
           {({fields: {name, password}, ...rest}) => (
             <Grid>
               <FlexCol>{name}</FlexCol>
@@ -690,34 +637,8 @@ describe('Form', () => {
 
       it('renders buttons ', () => {
         expect('.grid:eq(0) .col:eq(2)').toHaveClass('col-fixed');
-        expect('.grid:eq(0) .col:eq(2) .save').not.toBeDisabled();
+        expect('.grid:eq(0) .col:eq(2) .save').toBeDisabled();
         expect('.grid:eq(0) .col:eq(2) .cancel').not.toBeDisabled();
-      });
-
-      describe('when submitting the form', () => {
-        let caught;
-
-        beforeEach(() => {
-          try {
-            $('.form').simulate('submit');
-          } catch (e) {
-            caught = e;
-          }
-        });
-
-        it('sets errors in the form state', () => {
-          expect(subject.state.errors).toEqual({password: 'Please enter a value.'});
-        });
-
-        it('calls the onSubmitError callback', () => {
-          expect(onSubmitError).toHaveBeenCalledWith(jasmine.objectContaining({
-            message: 'Please enter values for all required fields.'
-          }));
-        });
-
-        it('throws the error', () => {
-          expect(caught).toEqual(jasmine.objectContaining({message: 'Please enter values for all required fields.'}));
-        });
       });
     });
   });
@@ -781,7 +702,6 @@ describe('Form', () => {
         <Form {...{
           className: 'some-form',
           afterSubmit,
-          onSubmitError,
           fields: {name: {initialValue: 'some-name'}, password: {initialValue: 'some-password', optional: true}}
         }}>
           {({fields: {name, password}, ...rest}) => (
@@ -842,34 +762,8 @@ describe('Form', () => {
       });
 
       it('renders buttons in a col-fixed col', () => {
-        expect('.grid:eq(0) .col:eq(2) .save').not.toBeDisabled();
+        expect('.grid:eq(0) .col:eq(2) .save').toBeDisabled();
         expect('.grid:eq(0) .col:eq(2) .cancel').not.toBeDisabled();
-      });
-
-      describe('when submitting the form', () => {
-        let caught;
-
-        beforeEach(() => {
-          try {
-            $('.form').simulate('submit');
-          } catch (e) {
-            caught = e;
-          }
-        });
-
-        it('sets errors in the form state', () => {
-          expect(subject.state.errors).toEqual({name: 'Please enter a value.'});
-        });
-
-        it('calls the onSubmitError callback', () => {
-          expect(onSubmitError).toHaveBeenCalledWith(jasmine.objectContaining({
-            message: 'Please enter values for all required fields.'
-          }));
-        });
-
-        it('throws the error', () => {
-          expect(caught).toEqual(jasmine.objectContaining({message: 'Please enter values for all required fields.'}));
-        });
       });
     });
   });

--- a/spec/pivotal-ui-react/forms/form_spec.js
+++ b/spec/pivotal-ui-react/forms/form_spec.js
@@ -895,17 +895,23 @@ describe('Form', () => {
       onModified = jasmine.createSpy('onModified');
 
       subject = ReactDOM.render(
-        <Form {...{className: 'some-form', afterSubmit, onModified, fields: {name: {initialValue: 'some-name'}}}}>
-          {({fields: {name}, ...rest}) => (
+        <Form {...{
+          className: 'some-form', afterSubmit, onModified, fields: {
+            name: {initialValue: 'some-name', optional: true},
+            checkboxField: {children: <Checkbox/>, optional: true}
+          }
+        }}>
+          {({fields: {name, checkboxField}, ...rest}) => (
             <Grid>
               <FlexCol>{name}</FlexCol>
+              <FlexCol>{checkboxField}</FlexCol>
               <FlexCol fixed>{Buttons({...rest})}</FlexCol>
             </Grid>
           )}
         </Form>, root);
     });
 
-    describe('when modifying', () => {
+    describe('when modifying the text field', () => {
       beforeEach(() => {
         $('fieldset > .grid:eq(0) > .col:eq(0) input').val('some-other-name').simulate('change');
       });
@@ -919,6 +925,66 @@ describe('Form', () => {
         beforeEach(() => {
           onModified.calls.reset();
           $('fieldset > .grid:eq(0) > .col:eq(0) input').val('some-name').simulate('change');
+        });
+
+        it('calls the onModified callback with false', () => {
+          expect(onModified).toHaveBeenCalledWith(false);
+          expect(onModified).not.toHaveBeenCalledWith(true);
+        });
+      });
+
+      describe('when resetting with the reset callback', () => {
+        beforeEach(() => {
+          onModified.calls.reset();
+          $('.cancel').click();
+        });
+
+        it('calls the onModified callback with false', () => {
+          expect(onModified).toHaveBeenCalledWith(false);
+          expect(onModified).not.toHaveBeenCalledWith(true);
+        });
+      });
+
+      describe('when submitting', () => {
+        beforeEach(() => {
+          onModified.calls.reset();
+          $('.save').click();
+          MockPromises.tick();
+        });
+
+        it('calls the onModified callback with false', () => {
+          expect(onModified).toHaveBeenCalledWith(false);
+          expect(onModified).not.toHaveBeenCalledWith(true);
+        });
+      });
+
+      describe('when unmounting', () => {
+        beforeEach(() => {
+          onModified.calls.reset();
+          ReactDOM.unmountComponentAtNode(root);
+        });
+
+        it('calls the onModified callback with false', () => {
+          expect(onModified).toHaveBeenCalledWith(false);
+          expect(onModified).not.toHaveBeenCalledWith(true);
+        });
+      });
+    });
+
+    describe('when modifying the checkbox field', () => {
+      beforeEach(() => {
+        $('fieldset > .grid:eq(0) > .col:eq(1) input').val(true).simulate('change');
+      });
+
+      it('calls the onModified callback with true', () => {
+        expect(onModified).toHaveBeenCalledWith(true);
+        expect(onModified).not.toHaveBeenCalledWith(false);
+      });
+
+      describe('when resetting manually', () => {
+        beforeEach(() => {
+          onModified.calls.reset();
+          $('fieldset > .grid:eq(0) > .col:eq(1) input').val(false).simulate('change');
         });
 
         it('calls the onModified callback with false', () => {

--- a/src/react/forms/form.js
+++ b/src/react/forms/form.js
@@ -131,13 +131,11 @@ export class Form extends React.Component {
     this.setState({current: cloneDeep(initial), errors: {}});
   };
 
-  canSubmit = ({checkRequiredFields} = {}) => {
+  canSubmit = ({checkRequiredFields = () => true} = {}) => {
     const {fields} = this.props;
     const {initial, current, submitting} = this.state;
 
     const isDiffFromInitial = find(Object.keys(initial), key => !deepEqual(initial[key], current[key]));
-    const requiredFields = Object.keys(fields).filter(name => fields[name] && !isOptional(fields[name], current));
-    const requiredFieldsHaveValue = requiredFields.every(name => current[name] || current[name] === 0);
 
     let passesValidators = true;
     for (const name in fields) {
@@ -150,20 +148,26 @@ export class Form extends React.Component {
       }
     }
 
-    return !submitting
-      && isDiffFromInitial
-      && (checkRequiredFields
-        ? checkRequiredFields(current)
-        : requiredFieldsHaveValue)
-      && passesValidators;
+    return !submitting && isDiffFromInitial && checkRequiredFields(current) && passesValidators;
   };
 
   onSubmit = e => {
     e && e.preventDefault();
-    const {onSubmit, onSubmitError, afterSubmit, onModified, resetOnSubmit} = this.props;
+    const {fields, onSubmit, onSubmitError = noop, afterSubmit, onModified, resetOnSubmit} = this.props;
     const {initial, current} = this.state;
     this.setState({submitting: true});
     const nextState = {submitting: false};
+
+    const requiredFields = Object.keys(fields).filter(name => fields[name] && !isOptional(fields[name], current));
+    const missingFields = requiredFields.filter(name => !current[name] && current[name] !== 0);
+
+    if (missingFields.length) {
+      const errors = missingFields.reduce((memo, name) => ({...memo, [name]: 'Please enter a value.'}), {});
+      this.setState({...nextState, errors});
+      const e = new Error('Please enter values for all required fields.');
+      onSubmitError(e);
+      throw e;
+    }
 
     const onSuccess = response => {
       this.setState({

--- a/src/react/forms/form.js
+++ b/src/react/forms/form.js
@@ -86,11 +86,17 @@ export class Form extends React.Component {
   }
 
   onChangeCheckbox = (name, cb) => val => {
+    const {initial, current} = this.state;
+    const value = !this.state.current[name];
+    const nextState = {current: {...current, [name]: value}};
+
     if (typeof val.persist === 'function') val.persist();
 
-    const nextValue = {[name]: !this.state.current[name]};
+    const nextValue = {[name]: value};
     if (cb) this.setValues(nextValue, () => cb(val));
     else this.setValues(nextValue);
+
+    if (this.props.onModified) this.props.onModified(!deepEqual(initial, nextState.current));
   };
 
   onChange = (name, validator, cb) => val => {


### PR DESCRIPTION
Currently, the Pivotal UI Form can be configured to block submits (gray out the submit button) with a `canSubmit` callback. This callback takes into account a few things, including but not limited to:
* Is the form dirty?
* Are all required fields filled out?

We want to enhance the Form component to delay checking required fields until after the user clicks the submit button. As a result, `canSubmit` will no longer need required fields to be filled out. When the form is submitted, new PUI Form logic will determine at this time whether all required fields are filled in. If not, the submit will be blocked, and errors will be placed in the internal errors state, so that they can be placed on the associated fields.

Notes:
* This PR builds on the changes in #587 
* `canSubmit` still takes `checkRequiredFields` and handles it the same way, to minimize breakage. Apps Manager should decide whether they still want this logic in `canSubmit`, or whether you believe it should also move to `onSubmit`.