### PR TITLE
Introduce `setErrors` callback to Form component

### DIFF
--- a/spec/pivotal-ui-react/forms/form_spec.js
+++ b/spec/pivotal-ui-react/forms/form_spec.js
@@ -1342,4 +1342,27 @@ describe('Form', () => {
       expect(subject.state.current).toEqual({name: 'some-other-name'});
     });
   });
+
+  describe('when rendering a form with initial errors', () => {
+    beforeEach(() => {
+      subject = ReactDOM.render(
+        <Form {...{
+          fields: {
+            title: {
+              children: <input/>
+            }
+          }
+        }}>
+          {({fields: {title}}) => {
+            return <Grid><FlexCol>{title}</FlexCol></Grid>;
+          }}
+        </Form>, root);
+      subject.setErrors({title: 'my title error'});
+    });
+
+    it('renders error text', () => {
+      expect('.form .form-unit').toHaveClass('has-error');
+      expect('.form .help-row').toHaveText('my title error');
+    });
+  });
 });

--- a/src/react/forms/form.js
+++ b/src/react/forms/form.js
@@ -195,14 +195,16 @@ export class Form extends React.Component {
 
   setValues = (values, cb) => this.setState({current: {...this.state.current, ...values}}, cb);
 
+  setErrors = (errors, cb) => this.setState({errors: {...this.state.errors, ...errors}}, cb);
+
   controlField = ({children = <Input type="text"/>, validator, name, ids}) => {
-    const {canSubmit, canReset, reset, onSubmit, setValues, state, onChange, onBlur, onChangeCheckbox} = this;
+    const {canSubmit, canReset, reset, onSubmit, setErrors, setValues, state, onChange, onBlur, onChangeCheckbox} = this;
     const {submitting} = state;
 
     const element = typeof children !== 'function'
       ? children
       : children({
-        onChange: onChange(name, validator), canSubmit, canReset, reset, onSubmit, submitting, setValues, state
+        onChange: onChange(name, validator), canSubmit, canReset, reset, onSubmit, submitting, setValues, setErrors, state
       });
 
     if (!element || React.Children.count(element) !== 1 || !name) return element;
@@ -231,7 +233,7 @@ export class Form extends React.Component {
   render() {
     // eslint-disable-next-line no-unused-vars
     const {className, children, fields, onModified, onSubmitError, afterSubmit, resetOnSubmit, ...others} = this.props;
-    const {canSubmit, canReset, reset, onSubmit, setValues, state, onBlur} = this;
+    const {canSubmit, canReset, reset, onSubmit, setValues, setErrors, state, onBlur} = this;
     const {current, submitting, ids} = state;
 
     const formUnits = {};
@@ -248,7 +250,7 @@ export class Form extends React.Component {
 
       formUnits[name] = (
         <FormUnit {...{
-          ...rest, key: name, optional: isOptional(rest, current), setValues, state, name, hasError: !!error,
+          ...rest, key: name, optional: isOptional(rest, current), setValues, setErrors, state, name, hasError: !!error,
           help, labelFor, children
         }}/>
       );
@@ -258,7 +260,7 @@ export class Form extends React.Component {
       <form {...{...others, className: classnames('form', className), onSubmit: this.onSubmit}}>
         <fieldset {...{disabled: submitting}}>
           {children({
-            fields: formUnits, canSubmit, canReset, reset, onSubmit, setValues, state, onBlur, submitting
+            fields: formUnits, canSubmit, canReset, reset, onSubmit, setValues, setErrors, state, onBlur, submitting
           })}
         </fieldset>
       </form>


### PR DESCRIPTION
- This allows the user to set any error messages that should appear on
initial render

Signed-off-by: Shaan Sapra <shsapra@pivotal.io>