### PR TITLE
Make title of checkbox dropdown configurable

### DIFF
--- a/docs/components/checkbox-dropdowns.md
+++ b/docs/components/checkbox-dropdowns.md
@@ -50,3 +50,4 @@ Property          | Required | Type                                | Default    
 `onChange`        | no       | Function                            |                | Callback that fires after clicking a checkbox
 `size`            | no       | oneOf(['normal', 'large', 'small']) | 'normal'       | Sets the size
 `split`           | no       | Boolean                             |                | If true, separates the button text from the toggle
+`customizeTitle`  | no       | Function                            |                | Callback that allows dropdown title customization if ALL are not selected

--- a/spec/react/checkbox-dropdown/checkbox_dropdown.spec.js
+++ b/spec/react/checkbox-dropdown/checkbox_dropdown.spec.js
@@ -263,4 +263,47 @@ describe('checkbox dropdown', () => {
       });
     });
   });
+
+  describe('when there is a custom title', () => {
+    let labels;
+    let title;
+
+    beforeEach(() => {
+      labels = ['item #1', 'item #2', 'item #3'];
+      title = (options) => {
+        const selected = Object.keys(options).filter(key => options[key])
+        if (selected.length > 0) {
+          return `Selected (${selected.length})`
+        }
+        return ''
+      }
+      subject = ReactDOM.render(<CheckboxDropdown labels={labels} title={title}/>, root);
+    });
+
+    it('the title text displays "ALL" when all are clicked', () => {
+      expect(document.querySelector('.dropdown > button')).toHaveText('ALL');
+    });
+
+    describe('when all are unclicked', () => {
+      beforeEach(() => {
+        document.querySelectorAll('.checkbox-dropdown-item-checkbox')[1].querySelector('input[type="checkbox"]').click();
+        document.querySelectorAll('.checkbox-dropdown-item-checkbox')[2].querySelector('input[type="checkbox"]').click();
+        document.querySelectorAll('.checkbox-dropdown-item-checkbox')[3].querySelector('input[type="checkbox"]').click();
+      });
+
+      it('the title changes to show "NONE"', () => {
+        expect(document.querySelector('.dropdown > button')).toHaveText('NONE');
+      })
+    });
+
+    describe('when some items are selected', () => {
+      beforeEach(() => {
+        document.querySelectorAll('.checkbox-dropdown-item-checkbox')[2].querySelector('input[type="checkbox"]').click();
+      });
+
+      it('the title changes to show the custom text when some items are selected ', () => {
+        expect(document.querySelector('.dropdown > button')).toHaveText('Selected (2)');
+      });
+    })
+  });
 });

--- a/spec/react/checkbox-dropdown/checkbox_dropdown.spec.js
+++ b/spec/react/checkbox-dropdown/checkbox_dropdown.spec.js
@@ -266,18 +266,18 @@ describe('checkbox dropdown', () => {
 
   describe('when there is a custom title', () => {
     let labels;
-    let title;
+    let customizeTitle;
 
     beforeEach(() => {
       labels = ['item #1', 'item #2', 'item #3'];
-      title = (options) => {
+      customizeTitle = (options) => {
         const selected = Object.keys(options).filter(key => options[key]);
         if (selected.length > 0) {
           return `Selected (${selected.length})`;
         }
         return '';
       };
-      subject = ReactDOM.render(<CheckboxDropdown labels={labels} title={title}/>, root);
+      subject = ReactDOM.render(<CheckboxDropdown labels={labels} customizeTitle={customizeTitle}/>, root);
     });
 
     it('the title text displays "ALL" when all are clicked', () => {

--- a/spec/react/checkbox-dropdown/checkbox_dropdown.spec.js
+++ b/spec/react/checkbox-dropdown/checkbox_dropdown.spec.js
@@ -271,12 +271,12 @@ describe('checkbox dropdown', () => {
     beforeEach(() => {
       labels = ['item #1', 'item #2', 'item #3'];
       title = (options) => {
-        const selected = Object.keys(options).filter(key => options[key])
+        const selected = Object.keys(options).filter(key => options[key]);
         if (selected.length > 0) {
-          return `Selected (${selected.length})`
+          return `Selected (${selected.length})`;
         }
-        return ''
-      }
+        return '';
+      };
       subject = ReactDOM.render(<CheckboxDropdown labels={labels} title={title}/>, root);
     });
 
@@ -293,7 +293,7 @@ describe('checkbox dropdown', () => {
 
       it('the title changes to show "NONE"', () => {
         expect(document.querySelector('.dropdown > button')).toHaveText('NONE');
-      })
+      });
     });
 
     describe('when some items are selected', () => {
@@ -304,6 +304,6 @@ describe('checkbox dropdown', () => {
       it('the title changes to show the custom text when some items are selected ', () => {
         expect(document.querySelector('.dropdown > button')).toHaveText('Selected (2)');
       });
-    })
+    });
   });
 });

--- a/src/react/checkbox-dropdown/checkbox_dropdown.js
+++ b/src/react/checkbox-dropdown/checkbox_dropdown.js
@@ -54,8 +54,8 @@ export class CheckboxDropdown extends React.Component {
   getTitle() {
     if (this.allSelected()) return 'ALL';
     const {options} = this.state;
-    const {title} = this.props
-    const selectedOptions = title(options)
+    const {title} = this.props;
+    const selectedOptions = title(options);
     if (!selectedOptions) return 'NONE';
     return selectedOptions;
   }

--- a/src/react/checkbox-dropdown/checkbox_dropdown.js
+++ b/src/react/checkbox-dropdown/checkbox_dropdown.js
@@ -7,6 +7,10 @@ import classnames from 'classnames';
 function doNothing() {
 }
 
+function getDefaultTitle(options) {
+  return Object.keys(options).filter(key => options[key]).join(', ');
+}
+
 export class CheckboxDropdown extends React.Component {
   static propTypes = {
     buttonAriaLabel: PropTypes.string,
@@ -17,9 +21,11 @@ export class CheckboxDropdown extends React.Component {
     size: PropTypes.oneOf(['normal', 'large', 'small']),
     split: PropTypes.bool,
     labels: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+    title: PropTypes.func,
   };
 
   static defaultProps = {
+    title: getDefaultTitle,
     onChange: doNothing,
     size: 'normal'
   };
@@ -48,7 +54,8 @@ export class CheckboxDropdown extends React.Component {
   getTitle() {
     if (this.allSelected()) return 'ALL';
     const {options} = this.state;
-    const selectedOptions = Object.keys(options).filter(key => options[key]).join(', ');
+    const {title} = this.props
+    const selectedOptions = title(options)
     if (!selectedOptions) return 'NONE';
     return selectedOptions;
   }

--- a/src/react/checkbox-dropdown/checkbox_dropdown.js
+++ b/src/react/checkbox-dropdown/checkbox_dropdown.js
@@ -21,11 +21,11 @@ export class CheckboxDropdown extends React.Component {
     size: PropTypes.oneOf(['normal', 'large', 'small']),
     split: PropTypes.bool,
     labels: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
-    title: PropTypes.func,
+    customizeTitle: PropTypes.func,
   };
 
   static defaultProps = {
-    title: getDefaultTitle,
+    customizeTitle: getDefaultTitle,
     onChange: doNothing,
     size: 'normal'
   };
@@ -54,8 +54,8 @@ export class CheckboxDropdown extends React.Component {
   getTitle() {
     if (this.allSelected()) return 'ALL';
     const {options} = this.state;
-    const {title} = this.props;
-    const selectedOptions = title(options);
+    const {customizeTitle} = this.props;
+    const selectedOptions = customizeTitle(options);
     if (!selectedOptions) return 'NONE';
     return selectedOptions;
   }
@@ -86,7 +86,7 @@ export class CheckboxDropdown extends React.Component {
 
   render() {
     // eslint-disable-next-line no-unused-vars
-    const {labels, onChange, className, ...dropDownProps} = this.props;
+    const {labels, onChange, className, customizeTitle, ...dropDownProps} = this.props;
     const {options} = this.state;
 
     const dropdownItems = Object.entries(options).map(([label, checked]) => {


### PR DESCRIPTION
Metrics would like to use the checkbox dropdown but with a different title. I believe the change is backwards compatible. If there is a better property name to use to prevent the warning from React about not recognizing a prop on a DOM element, please change the name.